### PR TITLE
Cache post-constructed objects

### DIFF
--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -80,9 +80,10 @@ class AreaManager:
         Returns:
             True if succeeded, False if failed.
         """
-        if filename in self.driftwood.resource:
+        map_json = self.driftwood.resource.request_json(filename)
+        if map_json:
             self.filename = filename
-            self.tilemap._read(self.driftwood.resource.request_json(filename))  # This should only be called from here.
+            self.tilemap._read(map_json)  # This should only be called from here.
             self.driftwood.log.info("Area", "loaded", filename)
 
             self.refocused = True


### PR DESCRIPTION
This branch changes the CacheManager to store completed JSON objects, ImageFiles, AudioFiles, and FontFiles instead of the contents of the file that they were sourced from.

This means if we request a resource a second time, it does not have to be parsed a second time, and also helps prevent a duplicate object (duplicate ImageFile, etc.) from being created since the original one is merely returned immediately.

Fixes #66.

Should also speed up loading scenes that share graphical/auditory assets.