### PR TITLE
Small WidgetManager refactor

### DIFF
--- a/data/test/blue1.py
+++ b/data/test/blue1.py
@@ -7,5 +7,5 @@ def setup():
         Driftwood.script.call("libs/stdlib/viewport.py", "rumble", 10, 3, None)
 
     h = Driftwood.widget.container(x=-1, y=-1, width=80, height=80)
-    Driftwood.widget.text("Test Text", "pf_arma_five.ttf", 16, container=h,
+    Driftwood.widget.text("Test Text", "pf_arma_five.ttf", 16, container_wid=h,
                           x=-1, y=-1, width=-1, height=-1, color="0000FFFF", active=True)

--- a/src/widgetmanager.py
+++ b/src/widgetmanager.py
@@ -116,56 +116,59 @@ class WidgetManager:
         Returns:
             Widget ID of the new container widget if succeeded, None if failed.
         """
-        # Set the variables.
         self.__last_wid += 1
-        self.widgets[self.__last_wid] = widget.Widget(self, "container")
-        self.widgets[self.__last_wid].wid = self.__last_wid
-        self.widgets[self.__last_wid].x = x
-        self.widgets[self.__last_wid].y = y
-        self.widgets[self.__last_wid].realx = x
-        self.widgets[self.__last_wid].realy = y
-        self.widgets[self.__last_wid].width = width
-        self.widgets[self.__last_wid].height = height
+
+        new_widget = widget.Widget(self, "container")
+        self.widgets[self.__last_wid] = new_widget
+
+        # Set the variables.
+        new_widget.wid = self.__last_wid
+        new_widget.x = x
+        new_widget.y = y
+        new_widget.realx = x
+        new_widget.realy = y
+        new_widget.width = width
+        new_widget.height = height
 
         # Center if not in a container.
         if container is None:
             if x == -1:
-                self.widgets[self.__last_wid].x = \
+                new_widget.x = \
                     (self.driftwood.window.logical_width // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    self.widgets[self.__last_wid].width // 2
-                self.widgets[self.__last_wid].realx = self.widgets[self.__last_wid].x
+                    new_widget.width // 2
+                new_widget.realx = new_widget.x
             if y == -1:
-                self.widgets[self.__last_wid].y = \
+                new_widget.y = \
                     (self.driftwood.window.logical_height // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    self.widgets[self.__last_wid].height // 2
-                self.widgets[self.__last_wid].realy = self.widgets[self.__last_wid].y
+                    new_widget.height // 2
+                new_widget.realy = new_widget.y
 
         else:
             if self.widgets[container].type == "container":  # It has a container.
-                self.widgets[self.__last_wid].container = container
+                new_widget.container = container
                 self.widgets[container].contains.append(self.__last_wid)
                 if self.widgets[container].realx and self.widgets[container].realy:  # Set the adjusted x and y.
                     # Either center or place in a defined position.
                     if x == -1:
-                        self.widgets[self.__last_wid].realx = self.widgets[container].realx + \
+                        new_widget.realx = self.widgets[container].realx + \
                                                               self.widgets[container].width // 2 - \
-                                                              self.widgets[self.__last_wid].width // 2
+                                                              new_widget.width // 2
                     else:
-                        self.widgets[self.__last_wid].realx += self.widgets[container].realx
+                        new_widget.realx += self.widgets[container].realx
 
                     if y == -1:
-                        self.widgets[self.__last_wid].realy = self.widgets[container].realy + \
+                        new_widget.realy = self.widgets[container].realy + \
                                                               self.widgets[container].height // 2 - \
-                                                              self.widgets[self.__last_wid].height // 2
+                                                              new_widget.height // 2
                     else:
-                        self.widgets[self.__last_wid].realy += self.widgets[container].realy
+                        new_widget.realy += self.widgets[container].realy
 
             else:  # Fake container.
                 self.driftwood.log.msg("ERROR", "Widget", "container", "not a container", container)
                 return None
 
         if imagefile:  # It has a background.
-            self.widgets[self.__last_wid].image = self.driftwood.resource.request_image(imagefile)
+            new_widget.image = self.driftwood.resource.request_image(imagefile)
 
         if active:  # Do we activate it to be drawn/used?
             self.activate(self.__last_wid)
@@ -193,79 +196,82 @@ class WidgetManager:
             Returns:
                 Widget ID of the new text widget.
         """
-        # Set the variables.
         self.__last_wid += 1
-        self.widgets[self.__last_wid] = widget.Widget(self, "text")
-        self.widgets[self.__last_wid].wid = self.__last_wid
-        self.widgets[self.__last_wid].contents = contents
-        self.widgets[self.__last_wid].ptsize = ptsize
-        self.widgets[self.__last_wid].x = x
-        self.widgets[self.__last_wid].y = y
-        self.widgets[self.__last_wid].realx = x
-        self.widgets[self.__last_wid].realy = y
-        self.widgets[self.__last_wid].width = width
-        self.widgets[self.__last_wid].height = height
 
-        self.widgets[self.__last_wid].font = self.driftwood.resource.request_font(font, ptsize)
-        if not self.widgets[self.__last_wid].font:
+        new_widget = widget.Widget(self, "text")
+        self.widgets[self.__last_wid] = new_widget
+
+        # Set the variables.
+        new_widget.wid = self.__last_wid
+        new_widget.contents = contents
+        new_widget.ptsize = ptsize
+        new_widget.x = x
+        new_widget.y = y
+        new_widget.realx = x
+        new_widget.realy = y
+        new_widget.width = width
+        new_widget.height = height
+
+        new_widget.font = self.driftwood.resource.request_font(font, ptsize)
+        if not new_widget.font:
             return None
 
         # Get text width and height.
         tw, th = c_int(), c_int()
-        TTF_SizeText(self.widgets[self.__last_wid].font.font, contents.encode(), byref(tw), byref(th))
-        self.widgets[self.__last_wid].textwidth, self.widgets[self.__last_wid].textheight = tw.value, th.value
+        TTF_SizeText(new_widget.font.font, contents.encode(), byref(tw), byref(th))
+        new_widget.textwidth, new_widget.textheight = tw.value, th.value
 
         # Set width and height if not overridden.
         if width == -1:
-            self.widgets[self.__last_wid].width = tw.value
+            new_widget.width = tw.value
         if height == -1:
-            self.widgets[self.__last_wid].height = th.value
+            new_widget.height = th.value
 
         # Center if not in a container.
         if container is None:
             if x == -1:
-                self.widgets[self.__last_wid].x = \
+                new_widget.x = \
                     (self.driftwood.window.logical_width // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    self.widgets[self.__last_wid].width // 2
-                self.widgets[self.__last_wid].realx = self.widgets[self.__last_wid].x
+                    new_widget.width // 2
+                new_widget.realx = new_widget.x
             if y == -1:
-                self.widgets[self.__last_wid].y = \
+                new_widget.y = \
                     (self.driftwood.window.logical_height // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    self.widgets[self.__last_wid].height // 2
-                self.widgets[self.__last_wid].realy = self.widgets[self.__last_wid].y
+                    new_widget.height // 2
+                new_widget.realy = new_widget.y
 
         # Are we inside a container?
         elif self.widgets[container].type == "container":
-            self.widgets[self.__last_wid].container = container
+            new_widget.container = container
             self.widgets[container].contains.append(self.__last_wid)
             if self.widgets[container].realx and self.widgets[container].realy:  # Set the adjusted x and y.
                 # Either center or place in a defined position.
                 if x == -1:
-                    self.widgets[self.__last_wid].realx = self.widgets[container].realx + \
+                    new_widget.realx = self.widgets[container].realx + \
                                                           self.widgets[container].width // 2 - \
-                                                          self.widgets[self.__last_wid].width // 2
+                                                          new_widget.width // 2
                 else:
-                    self.widgets[self.__last_wid].realx += self.widgets[container].realx
+                    new_widget.realx += self.widgets[container].realx
 
                 if y == -1:
-                    self.widgets[self.__last_wid].realy = self.widgets[container].realy + \
+                    new_widget.realy = self.widgets[container].realy + \
                                                           self.widgets[container].height // 2 - \
-                                                          self.widgets[self.__last_wid].height // 2
+                                                          new_widget.height // 2
                 else:
-                    self.widgets[self.__last_wid].realy += self.widgets[container].realy
+                    new_widget.realy += self.widgets[container].realy
 
         # Render.
         color_temp = SDL_Color()
         color_temp.r, color_temp.g, color_temp.b, color_temp.a = int(color[0:2], 16), int(color[2:4], 16), \
                                                                  int(color[4:6], 16), int(color[6:8], 16)
-        surface_temp = TTF_RenderUTF8_Solid(self.widgets[self.__last_wid].font.font, contents.encode(), color_temp)
+        surface_temp = TTF_RenderUTF8_Solid(new_widget.font.font, contents.encode(), color_temp)
 
         # Convert to a texture we can use internally.
         if surface_temp:
-            self.widgets[self.__last_wid].texture = SDL_CreateTextureFromSurface(self.driftwood.window.renderer,
+            new_widget.texture = SDL_CreateTextureFromSurface(self.driftwood.window.renderer,
                                                                                  surface_temp)
             SDL_FreeSurface(surface_temp)
-            if not self.widgets[self.__last_wid].texture:
+            if not new_widget.texture:
                 self.driftwood.log.msg("ERROR", "Widget", "text", "SDL", SDL_GetError())
         else:
             self.driftwood.log.msg("ERROR", "Widget", "text", "TTF", TTF_GetError())

--- a/src/widgetmanager.py
+++ b/src/widgetmanager.py
@@ -150,15 +150,15 @@ class WidgetManager:
                     # Either center or place in a defined position.
                     if x == -1:
                         new_widget.realx = self.widgets[container].realx + \
-                                                              self.widgets[container].width // 2 - \
-                                                              new_widget.width // 2
+                                           self.widgets[container].width // 2 - \
+                                           new_widget.width // 2
                     else:
                         new_widget.realx += self.widgets[container].realx
 
                     if y == -1:
                         new_widget.realy = self.widgets[container].realy + \
-                                                              self.widgets[container].height // 2 - \
-                                                              new_widget.height // 2
+                                           self.widgets[container].height // 2 - \
+                                           new_widget.height // 2
                     else:
                         new_widget.realy += self.widgets[container].realy
 
@@ -246,15 +246,15 @@ class WidgetManager:
                 # Either center or place in a defined position.
                 if x == -1:
                     new_widget.realx = self.widgets[container].realx + \
-                                                          self.widgets[container].width // 2 - \
-                                                          new_widget.width // 2
+                                       self.widgets[container].width // 2 - \
+                                       new_widget.width // 2
                 else:
                     new_widget.realx += self.widgets[container].realx
 
                 if y == -1:
                     new_widget.realy = self.widgets[container].realy + \
-                                                          self.widgets[container].height // 2 - \
-                                                          new_widget.height // 2
+                                       self.widgets[container].height // 2 - \
+                                       new_widget.height // 2
                 else:
                     new_widget.realy += self.widgets[container].realy
 
@@ -267,7 +267,7 @@ class WidgetManager:
         # Convert to a texture we can use internally.
         if surface_temp:
             new_widget.texture = SDL_CreateTextureFromSurface(self.driftwood.window.renderer,
-                                                                                 surface_temp)
+                                                              surface_temp)
             SDL_FreeSurface(surface_temp)
             if not new_widget.texture:
                 self.driftwood.log.msg("ERROR", "Widget", "text", "SDL", SDL_GetError())

--- a/src/widgetmanager.py
+++ b/src/widgetmanager.py
@@ -272,6 +272,8 @@ class WidgetManager:
         if active:  # Do we activate it to be drawn/used?
             self.activate(new_widget.wid)
 
+        return new_widget.wid
+
     def activate(self, wid):
         if wid in self.widgets:
             self.widgets[wid].active = True

--- a/src/widgetmanager.py
+++ b/src/widgetmanager.py
@@ -132,15 +132,14 @@ class WidgetManager:
 
         # Center if not in a container.
         if container is None:
+            window_logical_width = self.driftwood.window.logical_width
+            window_logical_height = self.driftwood.window.logical_height
+            window_zoom = self.driftwood.config["window"]["zoom"]
             if x == -1:
-                new_widget.x = \
-                    (self.driftwood.window.logical_width // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    new_widget.width // 2
+                new_widget.x = (window_logical_width // window_zoom - new_widget.width) // 2
                 new_widget.realx = new_widget.x
             if y == -1:
-                new_widget.y = \
-                    (self.driftwood.window.logical_height // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    new_widget.height // 2
+                new_widget.y = (window_logical_height // window_zoom - new_widget.height) // 2
                 new_widget.realy = new_widget.y
 
         else:
@@ -229,15 +228,14 @@ class WidgetManager:
 
         # Center if not in a container.
         if container is None:
+            window_logical_width = self.driftwood.window.logical_width
+            window_logical_height = self.driftwood.window.logical_height
+            window_zoom = self.driftwood.config["window"]["zoom"]
             if x == -1:
-                new_widget.x = \
-                    (self.driftwood.window.logical_width // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    new_widget.width // 2
+                new_widget.x = (window_logical_width // window_zoom - new_widget.width) // 2
                 new_widget.realx = new_widget.x
             if y == -1:
-                new_widget.y = \
-                    (self.driftwood.window.logical_height // self.driftwood.config["window"]["zoom"]) // 2 - \
-                    new_widget.height // 2
+                new_widget.y = (window_logical_height // window_zoom - new_widget.height) // 2
                 new_widget.realy = new_widget.y
 
         # Are we inside a container?

--- a/src/widgetmanager.py
+++ b/src/widgetmanager.py
@@ -145,7 +145,7 @@ class WidgetManager:
         else:
             if self.widgets[container].type == "container":  # It has a container.
                 new_widget.container = container
-                self.widgets[container].contains.append(self.__last_wid)
+                self.widgets[container].contains.append(new_widget.wid)
                 if self.widgets[container].realx and self.widgets[container].realy:  # Set the adjusted x and y.
                     # Either center or place in a defined position.
                     if x == -1:
@@ -170,9 +170,9 @@ class WidgetManager:
             new_widget.image = self.driftwood.resource.request_image(imagefile)
 
         if active:  # Do we activate it to be drawn/used?
-            self.activate(self.__last_wid)
+            self.activate(new_widget.wid)
 
-        return self.__last_wid
+        return new_widget.wid
 
     def text(self, contents, font, ptsize, container=None, x=0, y=0, width=-1, height=-1, color="000000FF",
              active=True):
@@ -241,7 +241,7 @@ class WidgetManager:
         # Are we inside a container?
         elif self.widgets[container].type == "container":
             new_widget.container = container
-            self.widgets[container].contains.append(self.__last_wid)
+            self.widgets[container].contains.append(new_widget.wid)
             if self.widgets[container].realx and self.widgets[container].realy:  # Set the adjusted x and y.
                 # Either center or place in a defined position.
                 if x == -1:
@@ -275,7 +275,7 @@ class WidgetManager:
             self.driftwood.log.msg("ERROR", "Widget", "text", "TTF", TTF_GetError())
 
         if active:  # Do we activate it to be drawn/used?
-            self.activate(self.__last_wid)
+            self.activate(new_widget.wid)
 
     def activate(self, wid):
         if wid in self.widgets:


### PR DESCRIPTION
Attempting to reduce some repetition in the code for widgetmanager.py. You should notice the average line length goes down a little and variable names are a bit shorter. This is almost entirely because I've introduced some local variables for commonly repeated expressions such as `new_widget` instead of `self.widgets[self.__last_wid]`.