### PR TITLE
Clear every frame to black before drawing

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -129,6 +129,7 @@ class Driftwood:
         self.audio = AudioManager(self)
         self.widget = WidgetManager(self)
         self.script = ScriptManager(self)
+        self.frame.register()
         self.area.register()
         self.window.register()
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -129,7 +129,6 @@ class Driftwood:
         self.audio = AudioManager(self)
         self.widget = WidgetManager(self)
         self.script = ScriptManager(self)
-        self.frame.register()
         self.area.register()
         self.window.register()
 

--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -115,6 +115,8 @@ class AreaManager:
                 self.driftwood.frame.prepare(self.tilemap.width * self.tilemap.tilewidth,
                                              self.tilemap.height * self.tilemap.tileheight)
                 self.refocused = False
+            else:
+                self.driftwood.frame.clear()
             self.__build_frame()
             self.changed = False
 

--- a/src/framemanager.py
+++ b/src/framemanager.py
@@ -75,6 +75,35 @@ class FrameManager:
 
         self.changed = self.STATE_NOTCHANGED
 
+    def register(self):
+        # Register the tick callback.
+        self.driftwood.tick.register(self._tick)
+
+    def _tick(self, seconds_past):
+        self.clear()
+
+    def clear(self):
+        """Clear the local workspace.
+
+        Returns:
+            True if succeeded, False if failed.
+        """
+        r = SDL_SetRenderTarget(self.driftwood.window.renderer, self.__workspace)
+        if type(r) is int and r < 0:
+            self.driftwood.log.msg("ERROR", "Frame", "clear", "SDL", SDL_GetError())
+            return False
+
+        # Clear the current workspace.
+        SDL_RenderClear(self.driftwood.window.renderer)
+
+        # Tell SDL to switch rendering back to the window's frame.
+        r = SDL_SetRenderTarget(self.driftwood.window.renderer, None)
+        if type(r) is int and r < 0:
+            self.driftwood.log.msg("ERROR", "Frame", "clear", "SDL", SDL_GetError())
+            return False
+
+        return True
+
     def prepare(self, width, height):
         """Prepare and clear the local workspace.
 

--- a/src/framemanager.py
+++ b/src/framemanager.py
@@ -75,13 +75,6 @@ class FrameManager:
 
         self.changed = self.STATE_NOTCHANGED
 
-    def register(self):
-        # Register the tick callback.
-        self.driftwood.tick.register(self._tick)
-
-    def _tick(self, seconds_past):
-        self.clear()
-
     def clear(self):
         """Clear the local workspace.
 


### PR DESCRIPTION
`AreaManager._tick()` is the first function called every frame in Driftwood's drawing process. If there's been a refocusing then AreaManager asks FrameManager to prepare a new frame. This new frame is black. Otherwise, the old frame is used and is not cleared, leaving garbage on-screen if the current draw does not overwrite every pixel.

We need to clear the frame really early in the drawing process, basically before `AreaManager.__build_frame()` is called since that's where we start `copy()`ing stuff.

This commit adds a FrameManager tick that is called before AreaManager's tick. All it does is clear the screen.

Fixes #75 