### PR TITLE
Crop entities to area

### DIFF
--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -167,6 +167,17 @@ class AreaManager:
                 # Get the source and destination rectangles needed by SDL_RenderCopy.
                 srcrect = entity.srcrect()
                 dstrect = [entity.x, entity.y - tall_amount, entity.width, entity.height]
+
+                # Clip entities so they don't appear off the top of the area boundary.
+                if dstrect[1] < 0:
+                    clip_amount = -dstrect[1]
+                    srcrect = list(srcrect)
+                    srcrect[1] += clip_amount
+                    srcrect[3] -= clip_amount
+                    dstrect[1] += clip_amount
+                    dstrect[3] -= clip_amount
+
+                # Area rumble et al.
                 dstrect[0] += self.offset[0]
                 dstrect[1] += self.offset[1]
 
@@ -179,9 +190,19 @@ class AreaManager:
                     tall_srcrect = list(entity.srcrect())
                     tall_dstrect = [entity.x, entity.y - tall_amount, entity.width,
                                     entity.height - (entity.height - tall_amount)]
+
+                    # Clip entities so they don't appear off the top of the area boundary.
+                    if tall_dstrect[1] < 0:
+                        clip_amount = -tall_dstrect[1]
+                        tall_srcrect[1] += clip_amount
+                        tall_srcrect[3] -= clip_amount
+                        tall_dstrect[1] += clip_amount
+                        tall_dstrect[3] -= clip_amount
+
                     tall_dstrect[0] += self.offset[0]
                     tall_dstrect[1] += self.offset[1]
                     tall_srcrect[3] = tall_dstrect[3]
+
                     tall_parts.append([entity.spritesheet.texture, tall_srcrect, tall_dstrect])
 
             # Draw the tall bits here.

--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -158,6 +158,13 @@ class AreaManager:
                 if r < 0:
                     self.driftwood.log.msg("ERROR", "Area", "__build_frame", "SDL", SDL_GetError())
 
+            arearect = (
+                0,
+                0,
+                self.tilemap.width * self.tilemap.tilewidth,
+                self.tilemap.height * self.tilemap.tileheight,
+            )
+
             tall_parts = []
 
             # Draw each entity on the layer into its position.
@@ -165,17 +172,23 @@ class AreaManager:
                 tall_amount = entity.height - self.tilemap.tileheight
 
                 # Get the source and destination rectangles needed by SDL_RenderCopy.
-                srcrect = entity.srcrect()
+                srcrect = list(entity.srcrect())
                 dstrect = [entity.x, entity.y - tall_amount, entity.width, entity.height]
 
-                # Clip entities so they don't appear off the top of the area boundary.
-                if dstrect[1] < 0:
-                    clip_amount = -dstrect[1]
-                    srcrect = list(srcrect)
-                    srcrect[1] += clip_amount
-                    srcrect[3] -= clip_amount
-                    dstrect[1] += clip_amount
-                    dstrect[3] -= clip_amount
+                # Clip entities so they don't appear outside the area.
+                clip_left = 0 if arearect[0] <= dstrect[0] else arearect[0] - dstrect[0]
+                clip_top = 0 if arearect[1] <= dstrect[1] else arearect[1] - dstrect[1]
+                clip_right = 0 if dstrect[0] + dstrect[2] <= arearect[2] else (dstrect[0] + dstrect[2]) - arearect[2]
+                clip_bot = 0 if dstrect[1] + dstrect[3] <= arearect[3] else (dstrect[1] + dstrect[3]) - arearect[3]
+
+                srcrect[0] += clip_left
+                dstrect[0] += clip_left
+                srcrect[1] += clip_top
+                dstrect[1] += clip_top
+                srcrect[2] -= clip_left + clip_right
+                dstrect[2] -= clip_left + clip_right
+                srcrect[3] -= clip_top + clip_bot
+                dstrect[3] -= clip_top + clip_bot
 
                 # Area rumble et al.
                 dstrect[0] += self.offset[0]
@@ -187,23 +200,32 @@ class AreaManager:
                     self.driftwood.log.msg("ERROR", "Area", "__build_frame", "SDL", SDL_GetError())
 
                 if tall_amount:  # It's taller than the tile. Figure out where to put the tall part.
-                    tall_srcrect = list(entity.srcrect())
-                    tall_dstrect = [entity.x, entity.y - tall_amount, entity.width,
-                                    entity.height - (entity.height - tall_amount)]
+                    srcrect = list(entity.srcrect())
+                    dstrect = [entity.x, entity.y - tall_amount, entity.width,
+                               entity.height - (entity.height - tall_amount)]
 
-                    # Clip entities so they don't appear off the top of the area boundary.
-                    if tall_dstrect[1] < 0:
-                        clip_amount = -tall_dstrect[1]
-                        tall_srcrect[1] += clip_amount
-                        tall_srcrect[3] -= clip_amount
-                        tall_dstrect[1] += clip_amount
-                        tall_dstrect[3] -= clip_amount
+                    srcrect[3] = dstrect[3]
 
-                    tall_dstrect[0] += self.offset[0]
-                    tall_dstrect[1] += self.offset[1]
-                    tall_srcrect[3] = tall_dstrect[3]
+                    # Clip entities so they don't appear outside the area.
+                    clip_left = 0 if arearect[0] <= dstrect[0] else arearect[0] - dstrect[0]
+                    clip_top = 0 if arearect[1] <= dstrect[1] else arearect[1] - dstrect[1]
+                    clip_right = 0 if dstrect[0] + dstrect[2] <= arearect[2] else (dstrect[0] + dstrect[2]) - arearect[2]
+                    clip_bot = 0 if dstrect[1] + dstrect[3] <= arearect[3] else (dstrect[1] + dstrect[3]) - arearect[3]
 
-                    tall_parts.append([entity.spritesheet.texture, tall_srcrect, tall_dstrect])
+                    srcrect[0] += clip_left
+                    dstrect[0] += clip_left
+                    srcrect[1] += clip_top
+                    dstrect[1] += clip_top
+                    srcrect[2] -= clip_left + clip_right
+                    dstrect[2] -= clip_left + clip_right
+                    srcrect[3] -= clip_top + clip_bot
+                    dstrect[3] -= clip_top + clip_bot
+
+                    # Area rumble et al.
+                    dstrect[0] += self.offset[0]
+                    dstrect[1] += self.offset[1]
+
+                    tall_parts.append([entity.spritesheet.texture, srcrect, dstrect])
 
             # Draw the tall bits here.
             for tall in tall_parts:

--- a/src/framemanager.py
+++ b/src/framemanager.py
@@ -273,8 +273,7 @@ class FrameManager:
         dst.x, dst.y, dst.w, dst.h = dstrect
 
         # Copy the texture onto the workspace.
-        r = SDL_RenderCopy(self.driftwood.window.renderer, tex, src,
-                           dst)
+        r = SDL_RenderCopy(self.driftwood.window.renderer, tex, src, dst)
         if type(r) is int and r < 0:
             self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
             ret = False


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/107998/25061107/4c06e26c-2163-11e7-8bd2-c1881f7d4b61.gif)

After:

![after](https://cloud.githubusercontent.com/assets/107998/25061108/529c2222-2163-11e7-8b72-b50c59258dc1.gif)

Fixes #75.