### PR TITLE
Widget: Don't terminate fonts on widget terminate

### DIFF
--- a/src/widget.py
+++ b/src/widget.py
@@ -237,5 +237,4 @@ class TextWidget(Widget):
         if self.texture:
             SDL_DestroyTexture(self.texture)
             self.texture = None
-        if self.font:
-            self.font._terminate()
+        self.font = None


### PR DESCRIPTION
This PR can be automatically merged.

But I'd like to say something while I'm here. Fonts & other cache-able resources (images, sounds, etc) shouldn't be terminated except by CacheManager.

- If an area creates a TextWidget, that widget loads a font. If the widget is terminated, it also terminates the font. If another TextWidget is created with the same font, the font is re-loaded from disk.
- When leaving an area, all widgets are destroyed. Therefore, all fonts are terminated. Therefore, any fonts that the new area uses have to be re-loaded.

This PR fixes the font reloading issue. A font will now only be loaded once. (Try leaving blue1 and coming back.) It looks like a similar thing might be going on in other places of the code, but I haven't checked. If you see any others, correct them!