### PR TITLE
Resource ownership

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,7 +28,8 @@
     "verbose": true,
     "halt": true,
     "suppress": [
-      ["Tick"]
+      ["Tick"],
+      ["Cache", "clean", "referrers"]
     ],
     "suppress_halt": [
       ["WARNING"]

--- a/config.json
+++ b/config.json
@@ -4,7 +4,6 @@
     "name": "test.db"
   },
   "cache": {
-    "enabled": true,
     "ttl": 300
   },
   "input": {

--- a/docsrc/01_Engine_Usage/02_Configuration_File.md
+++ b/docsrc/01_Engine_Usage/02_Configuration_File.md
@@ -15,7 +15,6 @@ Here is the configuration file that comes with this version of the engine:
     "name": "test.db"
   },
   "cache": {
-    "enabled": true,
     "ttl": 300
   },
   "input": {
@@ -81,15 +80,11 @@ The value of "name" is a string. It contains the filename of the database that w
 
 ## cache
 
-The "cache" section contains settings related to resource caching. When a resource is requested by the engine, it will be kept in memory in case it is needed again for a specified amount of time if the cache is enabled.
-
-### enabled
-
-The value of "enabled" is a boolean (true or false.) If this is set to false, resources will not be cached; instead they will disappear from memory after each use and have to be reloaded from the disk. You should probably leave this set to "true" unless you are running on a computer with very little RAM.
+The "cache" section contains settings related to resource caching. When a resource is requested by the engine, it will be kept in memory in case it is needed again for a specified amount of time.
 
 ### ttl
 
-The value of "ttl" is a number of seconds. This is the "time to live" for the cache -- the amount of time that a resource is held in memory after the most recent time it was used before dropping out of the cache. Decreasing this number will lower RAM usage, but may also increase load times if your computer has very slow storage. 300 (or 5 minutes) is generally a sensible value. Setting this to 0 disables the cache.
+The value of "ttl" is a number of seconds. This is the "time to live" for the cache -- the amount of time that a resource is held in memory after the most recent time it was used before dropping out of the cache. Decreasing this number will lower RAM usage, but may also increase load times if your computer has very slow storage. 300 (or 5 minutes) is generally a sensible value.
 
 ## input
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -207,7 +207,6 @@ class Driftwood:
         """
         self.audio._terminate()
         self.widget._terminate()
-        self.light._terminate()
         self.entity._terminate()
         self.database._terminate()
         self.frame._terminate()

--- a/src/audiomanager.py
+++ b/src/audiomanager.py
@@ -203,7 +203,6 @@ class AudioManager:
             if Mix_Playing(channel):
                 if not fade:  # Stop channel.
                     Mix_HaltChannel(channel)
-                    self.__sfx[channel][1]._terminate()
                     del self.__sfx[channel]
                 else:  # Fade out channel.
                     Mix_FadeOutChannel(channel, fade*1000)
@@ -231,7 +230,6 @@ class AudioManager:
                 else:
                     if not fade:  # Stop sfx.
                         Mix_HaltChannel(sfx)
-                        self.__sfx[sfx][1]._terminate()
                         del self.__sfx[sfx]
                     else:
                         Mix_FadeOutChannel(sfx, fade*1000)
@@ -349,7 +347,6 @@ class AudioManager:
         if Mix_PlayingMusic():
             if not fade:  # Stop the music.
                 Mix_HaltMusic()
-                self.__music._terminate()
                 self.__music = None
                 self.playing_music = False
             else:  # Fade out the music.
@@ -361,7 +358,6 @@ class AudioManager:
     def _cleanup(self, seconds_past):
         # Tick callback to clean up files we're done with.
         if self.__music and not Mix_PlayingMusic():
-            self.__music._terminate()
             self.__music = None
             self.playing_music = False
         try:
@@ -370,7 +366,6 @@ class AudioManager:
             else:
                 for sfx in self.__sfx:
                     if not Mix_Playing(sfx):
-                        self.__sfx[sfx][1]._terminate()
                         del self.__sfx[sfx]
         except RuntimeError:
             pass

--- a/src/cachemanager.py
+++ b/src/cachemanager.py
@@ -26,6 +26,8 @@
 # IN THE SOFTWARE.
 # **********
 
+import gc
+
 
 class CacheManager:
     """The Cache Manager
@@ -157,7 +159,13 @@ class CacheManager:
         # Collect expired filenames to be purged.
         for filename in self.__cache:
             if self.__now - self.__cache[filename]["timestamp"] >= self.driftwood.config["cache"]["ttl"]:
-                expired.append(filename)
+                referrers = gc.get_referrers(self.__cache[filename]["contents"])
+                referrers.remove(self.__cache[filename])
+
+                self.driftwood.log.info("Cache", "clean", "referrers", filename, referrers)
+
+                if not referrers:
+                    expired.append(filename)
 
         # Clean expired files
         if expired:

--- a/src/cachemanager.py
+++ b/src/cachemanager.py
@@ -127,7 +127,8 @@ class CacheManager:
             # If this file has a _terminate() function, be sure to call it first.
             if getattr(self.__cache[filename]["contents"], "_terminate", None):
                 self.__cache[filename]["contents"]._terminate()
-            if getattr(self.__cache[filename]["contents"], "_terminate", None):
+
+            if filename in self.__cache:
                 self.driftwood.log.info("Cache", "purged", filename)
                 del self.__cache[filename]
             else:

--- a/src/cachemanager.py
+++ b/src/cachemanager.py
@@ -125,8 +125,12 @@ class CacheManager:
             # If this file has a _terminate() function, be sure to call it first.
             if getattr(self.__cache[filename]["contents"], "_terminate", None):
                 self.__cache[filename]["contents"]._terminate()
-            del self.__cache[filename]
-            self.driftwood.log.info("Cache", "purged", filename)
+            if getattr(self.__cache[filename]["contents"], "_terminate", None):
+                self.driftwood.log.info("Cache", "purged", filename)
+                del self.__cache[filename]
+            else:
+                self.driftwood.log.msg("WARNING", "Cache", "purge", filename,
+                                       "file removed itself from cache while terminating")
 
         return True
 

--- a/src/cachemanager.py
+++ b/src/cachemanager.py
@@ -32,8 +32,8 @@ import gc
 class CacheManager:
     """The Cache Manager
 
-    This class handles the cache of recently used files. If enabled, files are stored in memory for a specified period
-    of time and up to the specified maximum cache size.
+    This class handles the cache of recently used files. Files are stored in memory for a specified period of time and
+    up to the specified maximum cache size.
 
     Attributes:
         driftwood: Base class instance.
@@ -51,15 +51,8 @@ class CacheManager:
         self.__ticks = 0
         self.__now = 0.0
 
-        # Check if the cache should be enabled.
-        if self.driftwood.config["cache"]["enabled"] and self.driftwood.config["cache"]["ttl"] > 0.0:
-            self.enabled = True
-
-            # Register the tick callback.
-            self.driftwood.tick.register(self._tick, delay=float(self.driftwood.config["cache"]["ttl"]))
-
-        else:
-            self.enabled = False
+        # Register the tick callback.
+        self.driftwood.tick.register(self._tick, delay=float(self.driftwood.config["cache"]["ttl"]))
 
     def __contains__(self, item):
         return item in self.__cache
@@ -74,7 +67,7 @@ class CacheManager:
         return self.__cache.keys()
 
     def upload(self, filename, contents):
-        """Upload a file into the cache if the cache is enabled.
+        """Upload a file into the cache.
 
         Args:
             filename: Filename of the file to upload.
@@ -83,9 +76,6 @@ class CacheManager:
         Returns:
             True if succeeded, false if failed.
         """
-        if not self.enabled:
-            return False
-
         # If a previous version existed, clean it up properly.
         if filename in self.__cache:
             self.purge(filename)

--- a/src/entity.py
+++ b/src/entity.py
@@ -381,9 +381,6 @@ class Entity:
         """
         if self.manager.driftwood.tick.registered(self.__next_member):
             self.manager.driftwood.tick.unregister(self.__next_member)
-        if self.spritesheet:
-            self.spritesheet._terminate()
-            self.spritesheet = None
 
 
 class TileModeEntity(Entity):

--- a/src/entitymanager.py
+++ b/src/entitymanager.py
@@ -278,7 +278,5 @@ class EntityManager:
         """
         for entity in self.entities:
             self.entities[entity]._terminate()
-        self.entities = {}
-        for spritesheet in self.spritesheets:
-            self.spritesheets[spritesheet]._terminate()
-        self.spritesheets = {}
+        self.entities = None
+        self.spritesheets = None

--- a/src/filetype.py
+++ b/src/filetype.py
@@ -64,14 +64,13 @@ class AudioFile:
     def _terminate(self):
         """Cleanup before deletion.
         """
-        if self.__is_music:
-            Mix_FreeMusic(self.audio)
-            self.audio = None
-        else:
-            Mix_FreeChunk(self.audio)
-            self.audio = None
-        if self.driftwood.cache.enabled:
-            self.driftwood.cache._reverse_purge(self)
+        if self.audio:
+            if self.__is_music:
+                Mix_FreeMusic(self.audio)
+                self.audio = None
+            else:
+                Mix_FreeChunk(self.audio)
+                self.audio = None
 
 
 class FontFile:
@@ -104,8 +103,6 @@ class FontFile:
         if self.font:
             TTF_CloseFont(self.font)
             self.font = None
-        if self.driftwood.cache.enabled:
-            self.driftwood.cache._reverse_purge(self)
 
 
 class ImageFile:
@@ -152,5 +149,3 @@ class ImageFile:
         if self.texture:
             SDL_DestroyTexture(self.texture)
             self.texture = None
-        if self.driftwood.cache.enabled:
-            self.driftwood.cache._reverse_purge(self)

--- a/src/filetype.py
+++ b/src/filetype.py
@@ -71,6 +71,8 @@ class AudioFile:
             else:
                 Mix_FreeChunk(self.audio)
                 self.audio = None
+        else:
+            self.driftwood.log.msg("WARNING", "AudioFile", "terminate", "subsequent termination of same object")
 
 
 class FontFile:
@@ -100,9 +102,13 @@ class FontFile:
                 self.driftwood.log.msg("ERROR", "FontFile", "__load", "SDL_TTF", TTF_GetError())
 
     def _terminate(self):
+        """Cleanup before deletion.
+        """
         if self.font:
             TTF_CloseFont(self.font)
             self.font = None
+        else:
+            self.driftwood.log.msg("WARNING", "FontFile", "terminate", "subsequent termination of same object")
 
 
 class ImageFile:
@@ -143,6 +149,10 @@ class ImageFile:
                 self.driftwood.log.msg("ERROR", "ImageFile", "__load", "SDL_Image", IMG_GetError())
 
     def _terminate(self):
+        """Cleanup before deletion.
+        """
+        if not self.surface and not self.texture:
+            self.driftwood.log.msg("WARNING", "ImageFile", "terminate", "subsequent termination of same object")
         if self.surface:
             SDL_FreeSurface(self.surface)
             self.surface = None

--- a/src/framemanager.py
+++ b/src/framemanager.py
@@ -142,8 +142,6 @@ class FrameManager:
 
         # Prevent this ImageFile (probably from a script) from losing scope and taking our texture with it.
         elif isinstance(tex, filetype.ImageFile):
-            if self.__imagefile and tex is not self.__imagefile:
-                self.__imagefile._terminate()
             self.__imagefile = tex
             if self.__frontbuffer and self.__imagefile.texture is not self.__frontbuffer:
                 SDL_DestroyTexture(self.__frontbuffer)

--- a/src/light.py
+++ b/src/light.py
@@ -80,7 +80,3 @@ class Light:
             self.manager.driftwood.tick.unregister(self._track_entity)
 
         self.manager.driftwood.area.changed = True
-
-    def _terminate(self):
-        if self.lightmap:
-            self.lightmap._terminate()

--- a/src/lightmanager.py
+++ b/src/lightmanager.py
@@ -86,7 +86,7 @@ class LightManager:
         Returns: New light if succeeded, None if failed.
         """
         # Try to request the lightmap image from the resource manager.
-        lightmap = self.driftwood.resource.request_image(filename, False)
+        lightmap = self.driftwood.resource.request_image(filename)
         if not lightmap:
             self.driftwood.log.msg("ERROR", "Light", "insert", "could not load lightmap", lightmap)
             return None
@@ -255,7 +255,6 @@ class LightManager:
             True if succeeded, False if failed.
         """
         if lid in self.lights:
-            self.lights[lid]._terminate()
             del self.lights[lid]
             self.driftwood.area.changed = True
             return True
@@ -288,7 +287,6 @@ class LightManager:
 
         # Kill the lights in the list.
         for lid in to_kill:
-            self.lights[lid]._terminate()
             del self.lights[lid]
 
         self.driftwood.area.changed = True
@@ -304,16 +302,7 @@ class LightManager:
 
         Returns: True
         """
-        for light in self.lights:
-            self.lights[light]._terminate()
         self.lights = {}
         self.driftwood.area.changed = True
         self.driftwood.log.info("Light", "reset")
         return True
-
-    def _terminate(self):
-        """Cleanup before deletion.
-        """
-        for light in self.lights:
-            self.lights[light]._terminate()
-        self.lights = {}

--- a/src/logmanager.py
+++ b/src/logmanager.py
@@ -110,7 +110,7 @@ class LogManager:
         for supp in check:
             if supp[0] == chain[0] and len(chain) >= len(supp):
                 for n, s in enumerate(supp):
-                    if s == chain[n] or not s:
-                        return True
-                    else:
+                    if s and s != chain[n]:
                         return False
+                return True
+        return False

--- a/src/resourcemanager.py
+++ b/src/resourcemanager.py
@@ -40,7 +40,6 @@ class ResourceManager:
 
     Attributes:
         driftwood: Base class instance.
-
     """
 
     def __init__(self, driftwood):
@@ -99,7 +98,7 @@ class ResourceManager:
         """
         if filename in self.driftwood.cache:
             return self.driftwood.cache[filename]
-        data = self._request(filename)
+        data = self._request(filename, binary=False)
         if data:
             if type(data) == bytes:
                 data = data.decode()
@@ -122,7 +121,7 @@ class ResourceManager:
         """
         if filename in self.driftwood.cache:
             return self.driftwood.cache[filename]
-        data = self._request(filename, True)
+        data = self._request(filename, binary=True)
         if data:
             obj = filetype.AudioFile(self.driftwood, data, music)
             self.driftwood.cache.upload(filename, obj)
@@ -144,7 +143,7 @@ class ResourceManager:
         cache_name = filename + ":" + str(ptsize)
         if cache_name in self.driftwood.cache:
             return self.driftwood.cache[cache_name]
-        data = self._request(filename, True)
+        data = self._request(filename, binary=True)
         if data:
             obj = filetype.FontFile(self.driftwood, data, ptsize)
             self.driftwood.cache.upload(cache_name, obj)
@@ -153,35 +152,32 @@ class ResourceManager:
             self.driftwood.cache.upload(cache_name, None)
             return None
 
-    def request_image(self, filename, cache=True):
+    def request_image(self, filename):
         """Retrieve an internal abstraction of an image file.
 
         Args:
             filename: The filename of the image file to load.
-            cache: Whether to cache the file.
 
         Returns:
             Image filetype abstraction if succeeded, None if failed.
         """
         if filename in self.driftwood.cache:
             return self.driftwood.cache[filename]
-        data = self._request(filename, True)
+        data = self._request(filename, binary=True)
         if data:
             obj = filetype.ImageFile(self.driftwood, data, self.driftwood.window.renderer)
-            if cache:
-                self.driftwood.cache.upload(filename, obj)
+            self.driftwood.cache.upload(filename, obj)
             return obj
         else:
             self.driftwood.cache.upload(filename, None)
             return None
 
-    def _request(self, filename, binary=False, cache=False):
+    def _request(self, filename, binary=False):
         """Retrieve the contents of a file.
 
         Args:
             filename: Filename of the file to read.
             binary: Whether the file is a binary file, rather than a plaintext file.
-            cache: Whether to upload the data to the cache inside this function.
 
         Returns:
             Contents of the requested file, if present. Otherwise None.
@@ -206,10 +202,6 @@ class ResourceManager:
                 else:  # This is hopefully a zip archive.
                     with zipfile.ZipFile(pathname, 'r') as zf:
                         contents = zf.read(filename)
-
-                # Upload the file to the cache.
-                if cache:
-                    self.driftwood.cache.upload(filename, contents)
 
                 return contents
 

--- a/src/schema/config.json
+++ b/src/schema/config.json
@@ -19,16 +19,12 @@
     "cache": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
         "ttl": {
           "type": "number",
-          "minimum": 0
+          "minimum": 1
         }
       },
       "required": [
-        "enabled",
         "ttl"
       ]
     },

--- a/src/spritesheet.py
+++ b/src/spritesheet.py
@@ -68,13 +68,3 @@ class Spritesheet:
         tw, th = c_int(), c_int()
         SDL_QueryTexture(self.texture, None, None, byref(tw), byref(th))
         self.imagewidth, self.imageheight = tw.value, th.value
-
-    def _terminate(self):
-        """Cleanup before deletion.
-        """
-        if self.image:
-            self.image._terminate()
-            self.image = None
-        if self.texture:
-            SDL_DestroyTexture(self.texture)
-            self.texture = None

--- a/src/tilemap.py
+++ b/src/tilemap.py
@@ -146,10 +146,3 @@ class Tilemap:
         if gobjlayer:
             for l in self.layers:
                 l._process_objects(gobjlayer)
-
-    def _terminate(self):
-        """Cleanup before deletion.
-        """
-        for t in range(len(self.tilesets)):
-            self.tilesets[t]._terminate()
-        self.tilesets = []

--- a/src/tileset.py
+++ b/src/tileset.py
@@ -103,13 +103,3 @@ class Tileset:
         if "tileproperties" in self.__tileset:
             for key in self.__tileset["tileproperties"].keys():
                 self.tileproperties[int(key)] = self.__tileset["tileproperties"][key]
-
-    def _terminate(self):
-        """Cleanup before deletion.
-        """
-        if self.image:
-            self.image._terminate()
-            self.image = None
-        if self.texture:
-            SDL_DestroyTexture(self.texture)
-            self.texture = None

--- a/src/widget.py
+++ b/src/widget.py
@@ -125,13 +125,6 @@ class ContainerWidget(Widget):
 
         return True
 
-    def _terminate(self):
-        """Cleanup before deletion.
-        """
-        if self.image:
-            self.image._terminate()
-            self.image = None
-
 
 class TextWidget(Widget):
     """This subclass represents a text widget.
@@ -233,5 +226,3 @@ class TextWidget(Widget):
         if self.texture:
             SDL_DestroyTexture(self.texture)
             self.texture = None
-        if self.font:
-            self.font._terminate()

--- a/src/widgetmanager.py
+++ b/src/widgetmanager.py
@@ -217,12 +217,13 @@ class WidgetManager:
 
     def kill(self, wid):
         """Kill a widget.
-        
+
         Args:
             wid: Widget id of widget to kill.
         """
         if wid in self.widgets:
-            self.widgets[wid]._terminate()
+            if getattr(self.widgets[wid], "_terminate", None):
+                self.widgets[wid]._terminate()
             del self.widgets[wid]
             self.driftwood.area.changed = True
             return True
@@ -231,7 +232,7 @@ class WidgetManager:
 
     def widget(self, wid):
         """Get a widget by widget id.
-        
+
         Args:
             wid: The widget id of the widget to return.
         """
@@ -243,7 +244,8 @@ class WidgetManager:
         """Destroy all widgets.
         """
         for widget in self.widgets:
-            self.widgets[widget]._terminate()
+            if getattr(self.widgets[widget], "_terminate", None):
+                self.widgets[widget]._terminate()
         self.widgets = {}
         self.selected = None
         return True
@@ -280,6 +282,7 @@ class WidgetManager:
         """Cleanup before deletion.
         """
         for widget in self.widgets:
-            self.widgets[widget]._terminate()
+            if getattr(self.widgets[widget], "_terminate", None):
+                self.widgets[widget]._terminate()
         self.widgets = {}
         TTF_Quit()


### PR DESCRIPTION
Fixes #111.

Make CacheManager own & be in charage of terminating all resources from `filetype.py`. Nobody besides CacheManager will terminate these resources anymore.

Increase the cache hit rate of various subsystems, especially LightManager and WidgetManager but others too, speeding up loading of new areas & creation of new widgets, etc.

Reduce memory and CPU usage because of the above, including on computers with low RAM because multiple users of a resource share the same single instance.

Remove the ability to disable the cache. Having a low TTL cache reduces RAM better than turning the cache off. For bonus points, having a cache with low TTL is faster than having no cache.

Simplify logic and fix crashes. This PR strips out a lot of manual memory managment code and has an overall negative line count. Hurray!

Uses a CPython-specific API. We use CPython's internal reference count of objects to know when it's safe to delete them now. (Rather than trying to keep our own reference counting, we piggy-back on CPython here since they already do this for all objects.) This means we'll never try to delete an object in use, but increases our vulnerability to memory leaks. If somebody holds on to a resource through a dangling reference somewhere, we're not going to automatically detect it. Going forward we can monitor the cache at various points along Driftwood's development to see if everything we expect to get purged is.