### PR TITLE
Custom triggers

### DIFF
--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -55,7 +55,7 @@ class AreaManager:
 
         self.filename = ""
 
-        self.tilemap = tilemap.Tilemap(self)
+        self.tilemap = tilemap.Tilemap(driftwood, self)
 
         self.changed = False
 

--- a/src/scriptmanager.py
+++ b/src/scriptmanager.py
@@ -54,7 +54,7 @@ class ScriptManager:
         self.driftwood = driftwood
 
         # Double dictionary of custom triggers mapped by name.
-        self.triggers = {}  # {name: {"event", "func", "nargs", "minargs"}}
+        self.custom_triggers = {}  # {name: {"event", "func", "nargs", "minargs"}}
 
         # Dictionary of module instances mapped by filename.
         self.__modules = {}
@@ -110,26 +110,27 @@ class ScriptManager:
         else:
             return None
 
-    def define(self, name, event, func, nargs, minargs=-1):
+    def define(self, name, event, filename, func, nargs, minargs=None):
         """Define a custom trigger that can be called directly from a map property.
-        
+
         Ex. A trigger named "mytrigger" of type "on_tile" with 4 arguments can be called when the player steps onto
         that tile by setting the property "mytrigger": "a,b,c,d" on the tile in the map editor. All comma-separated
         arguments are passed as strings.
-        
+
         Args:
             name: Name by which the trigger is referenced.
             event: Type of event on which to activate the trigger. [on_tile, on_layer, on_enter, on_exit, on_focus,
-                                                                   on_blur]
-            func: The function to be called when the trigger is activated.
+                                                                    on_blur]
+            filename: The filename where the function is located.
+            func: The name of the function to be called when the trigger is activated.
             nargs: Number of arguments to take.
             minargs: If set, a minimum number of arguments less than nargs which may be taken.
-        
+
         Returns:
             True if succeeded, False if failed.
         """
         # Perform checks on input.
-        if name in self.triggers:
+        if name in self.custom_triggers:
             self.driftwood.log.msg("ERROR", "Script", "define", "already defined", name)
             return False
 
@@ -137,20 +138,30 @@ class ScriptManager:
             self.driftwood.log.msg("ERROR", "Script", "define", "invalid event", event)
             return False
 
-        if type(func) is not function:
-            self.driftwood.log.msg("ERROR", "Script", "define", "not a function", func)
+        if not isinstance(filename, str):
+            self.driftwood.log.msg("ERROR", "Script", "define", "not a string", filename)
+            return False
+
+        if not isinstance(func, str):
+            self.driftwood.log.msg("ERROR", "Script", "define", "not a string", func)
             return False
 
         if nargs < 0:
             self.driftwood.log.msg("ERROR", "Script", "define", "nargs is less than 0")
             return False
 
-        if minargs is not -1 and minargs > nargs:
+        if minargs and minargs > nargs:
             self.driftwood.log.msg("ERROR", "Script", "define", "minargs is more than nargs")
             return False
 
         # Insert the trigger.
-        self.triggers[name] = {"event": event, "func": func, "nargs": nargs, "minargs": minargs}
+        self.custom_triggers[name] = {
+            "event": event,
+            "filename": filename,
+            "func": func,
+            "nargs": nargs,
+            "minargs": minargs
+        }
         self.driftwood.log.info("Script", "defined", "{0} trigger \"{1}\"".format(event, name))
         return True
 
@@ -164,14 +175,37 @@ class ScriptManager:
             True if succeeded, False if failed.
         """
         # Does this exist?
-        if name in self.triggers:
-            del self.triggers[name]
+        if name in self.custom_triggers:
+            del self.custom_triggers[name]
             self.driftwood.log.info("Script", "undefined trigger", name)
             return True
 
         # Failure.
         self.driftwood.log.msg("ERROR", "Script", "undefine", "no such trigger", name)
         return False
+
+    def is_custom_trigger(self, property_name):
+        return property_name in self.custom_triggers
+
+    def lookup(self, property_name, property):
+        if property_name in self.custom_triggers:
+            custom_trigger = self.custom_triggers[property_name]
+            event = custom_trigger["event"]
+            filename = custom_trigger["filename"]
+            func = custom_trigger["func"]
+            minargs = custom_trigger["minargs"]
+            nargs = custom_trigger["nargs"]
+            args = property.split(',')
+            if minargs is not None:
+                if args < minargs:
+                    self.driftwood.log.msg("ERROR", "Tilemap", "read", property_name, "too few args")
+                    return None
+            elif nargs != len(args):
+                self.driftwood.log.msg("ERROR", "Tilemap", "read", property_name, "incorrect number of args")
+                return None
+            return event, filename + "," + func + "," + ",".join(args)
+        else:
+            return None
 
     def __convert_path(self, filename):
         """Get around a documented zipimport flaw.

--- a/src/tilemap.py
+++ b/src/tilemap.py
@@ -46,12 +46,14 @@ class Tilemap:
         tilesets: The list of Tileset class instances for each tileset.
     """
 
-    def __init__(self, area):
+    def __init__(self, driftwood, area):
         """Tilemap class initializer.
 
         Args:
+            driftwood: Base class instance.
             area: Link back to the parent AreaManager instance.
         """
+        self.driftwood = driftwood
         self.area = area
 
         # Attributes which will be updated with information about the map.
@@ -108,6 +110,8 @@ class Tilemap:
         else:
             self.properties = {}
 
+        self.__expand_properties()
+
         # Call the on_enter event if set.
         if "on_load" in self.properties:
             self.area.driftwood.script.call(*self.properties["on_load"].split(','))
@@ -131,7 +135,7 @@ class Tilemap:
 
             # This is a tile layer.
             if l["type"] == "tilelayer":
-                self.layers.append(layer.Layer(self, l, zpos))
+                self.layers.append(layer.Layer(self.driftwood, self, l, zpos))
 
             # This is an object layer.
             elif l["type"] == "objectgroup":
@@ -145,7 +149,24 @@ class Tilemap:
         # Merge the global object layer into all tile layers.
         if gobjlayer:
             for l in self.layers:
-                l._process_objects(gobjlayer)
+               l._process_objects(gobjlayer)
+
+    def __expand_properties(self):
+        new_props = {}
+        old_props = []
+
+        # Expand user-defined trigger shortcuts
+        for property_name in self.properties:
+            if self.driftwood.script.is_custom_trigger(property_name):
+                property = self.properties[property_name]
+                event, trigger = self.driftwood.script.lookup(property_name, property)
+                new_props[event] = trigger
+                old_props.append(property_name)
+
+        for event in new_props:
+            self.properties[event] = new_props[event]
+        for prop in old_props:
+            del self.properties[prop]
 
     def _terminate(self):
         """Cleanup before deletion.


### PR DESCRIPTION
Fixes #54.

Some duplicated code, but otherwise pretty straightforward.

Adds custom triggers to area properties and tile object properties. Does not restrict the event types to either of the properties. So you can define an `on_tile` property inside an area and an `on_focus` on a tile object. This could be more strict, but the base functionality is there.