### PR TITLE
Restore alpha/blend mode/color mod functionality

### DIFF
--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -164,7 +164,8 @@ class AreaManager:
                 dstrect[0] += self.offset[0]
                 dstrect[1] += self.offset[1]
 
-                r = self.driftwood.frame.copy(light.lightmap.texture, srcrect, dstrect)
+                r = self.driftwood.frame.copy(light.lightmap.texture, srcrect, dstrect, alpha=light.alpha,
+                                              blendmode=light.blendmode, colormod=light.colormod)
                 if r < 0:
                     self.driftwood.log.msg("ERROR", "Area", "__build_frame", "SDL", SDL_GetError())
 

--- a/src/framemanager.py
+++ b/src/framemanager.py
@@ -27,7 +27,7 @@
 # **********
 
 from ctypes import byref
-from ctypes import c_int
+from ctypes import c_int, c_ubyte
 from sdl2 import *
 
 import filetype
@@ -263,17 +263,41 @@ class FrameManager:
             self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
             ret = False
 
+        prev_alpha = None
+        prev_blendmode = None
+        prev_colormod = None
+
         if alpha:
+            prev_alpha = c_ubyte()
+            r = SDL_GetTextureAlphaMod(tex, byref(prev_alpha))
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
+
             r = SDL_SetTextureAlphaMod(tex, alpha)
             if type(r) is int and r < 0:
                 self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
                 ret = False
+
         if blendmode:
+            prev_blendmode = c_int()
+            r = SDL_GetTextureBlendMode(tex, byref(prev_blendmode))
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
+
             r = SDL_SetTextureBlendMode(tex, blendmode)
             if type(r) is int and r < 0:
                 self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
                 ret = False
+
         if colormod:
+            prev_colormod = (c_ubyte(), c_ubyte(), c_ubyte())
+            r = SDL_GetTextureColorMod(tex, byref(prev_colormod[0]), byref(prev_colormod[1]), byref(prev_colormod[2]))
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
+
             r = SDL_SetTextureColorMod(tex, *colormod)
             if type(r) is int and r < 0:
                 self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
@@ -286,17 +310,19 @@ class FrameManager:
             ret = False
 
         if alpha:
-            r = SDL_SetTextureAlphaMod(tex, 255)
+            r = SDL_SetTextureAlphaMod(tex, prev_alpha.value)
             if type(r) is int and r < 0:
                 self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
                 ret = False
+
         if blendmode:
-            r = SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND)
+            r = SDL_SetTextureBlendMode(tex, prev_blendmode.value)
             if type(r) is int and r < 0:
                 self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
                 ret = False
+
         if colormod:
-            r = SDL_SetTextureColorMod(tex, 255, 255, 255)
+            r = SDL_SetTextureColorMod(tex, prev_colormod[0].value, prev_colormod[1].value, prev_colormod[2].value)
             if type(r) is int and r < 0:
                 self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
                 ret = False

--- a/src/framemanager.py
+++ b/src/framemanager.py
@@ -232,7 +232,7 @@ class FrameManager:
 
         return True
 
-    def copy(self, tex, srcrect, dstrect, direct=False):
+    def copy(self, tex, srcrect, dstrect, direct=False, alpha=None, blendmode=None, colormod=None):
         """Copy a texture onto the back buffer.
         
         Copy the source rectangle from the texture tex to the destination rectangle in our back buffer.
@@ -249,6 +249,12 @@ class FrameManager:
         # We have to finish before we return.
         ret = True
 
+        # Set up the rectangles.
+        src = SDL_Rect()
+        dst = SDL_Rect()
+        src.x, src.y, src.w, src.h = srcrect
+        dst.x, dst.y, dst.w, dst.h = dstrect
+
         if direct:
             r = SDL_SetRenderTarget(self.driftwood.window.renderer, self.__frontbuffer)
         else:  # Tell SDL to render to our back buffer instead of the window's frame.
@@ -257,17 +263,43 @@ class FrameManager:
             self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
             ret = False
 
-        # Set up the rectangles.
-        src = SDL_Rect()
-        dst = SDL_Rect()
-        src.x, src.y, src.w, src.h = srcrect
-        dst.x, dst.y, dst.w, dst.h = dstrect
+        if alpha:
+            r = SDL_SetTextureAlphaMod(tex, alpha)
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
+        if blendmode:
+            r = SDL_SetTextureBlendMode(tex, blendmode)
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
+        if colormod:
+            r = SDL_SetTextureColorMod(tex, *colormod)
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
 
         # Copy the texture onto the back buffer.
         r = SDL_RenderCopy(self.driftwood.window.renderer, tex, src, dst)
         if type(r) is int and r < 0:
             self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
             ret = False
+
+        if alpha:
+            r = SDL_SetTextureAlphaMod(tex, 255)
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
+        if blendmode:
+            r = SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND)
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
+        if colormod:
+            r = SDL_SetTextureColorMod(tex, 255, 255, 255)
+            if type(r) is int and r < 0:
+                self.driftwood.log.msg("ERROR", "Frame", "copy", "SDL", SDL_GetError())
+                ret = False
 
         # Tell SDL to switch rendering back to the window's frame.
         r = SDL_SetRenderTarget(self.driftwood.window.renderer, None)

--- a/src/light.py
+++ b/src/light.py
@@ -32,8 +32,7 @@ class Light:
     Attributes:
         Same as __init__ args.
     """
-
-    def __init__(self, manager, lid, lightmap, layer, x, y, w, h, color, blend=False, entity=None, layermod=0):
+    def __init__(self, manager, lid, lightmap, layer, x, y, w, h, alpha, blendmode, colormod, entity, layermod):
         """Light class initializer.
 
         Args:
@@ -46,8 +45,9 @@ class Light:
             y: y-coordinate in pixels.
             w: Width of the light.
             h: Height of the light.
-            color: Hexadeximal color and alpha value of the light. "RRGGBBAA"
-            blend: Whether to blend light instead of adding it. Useful for dark lights.
+            alpha: Alpha value of the light.
+            blendmode: Whether to blend light instead of adding it. Useful for dark lights.
+            colormod: RGB-triple of color value of the light.
             entity: If set, eid of entity to track the light to. Disabled if None.
             layermod: Integer to add to the layer the light is drawn on when tracking an entity.
         """
@@ -60,8 +60,9 @@ class Light:
         self.y = y
         self.w = w
         self.h = h
-        self.color = color
-        self.blend = blend
+        self.alpha = alpha
+        self.blendmode = blendmode
+        self.colormod = colormod
         self.entity = entity
 
         if entity is not None:

--- a/src/lightmanager.py
+++ b/src/lightmanager.py
@@ -108,27 +108,24 @@ class LightManager:
         self.__last_lid += 1
         lid = self.__last_lid
 
-        # Assign the light to its light id in the dictionary.
-        self.lights[lid] = light.Light(self, lid, lightmap, layer, x, y, w, h, color, blend, entity, layermod)
+        # Give the light transparency.
+        alpha = int(color[6:8], 16)
 
-        # Are we blending the light? Try it.
+        # Are we blending the light?
+        blendmode = SDL_BLENDMODE_ADD
         if blend:
-            r = SDL_SetTextureBlendMode(self.lights[lid].lightmap.texture, SDL_BLENDMODE_BLEND)
-        else:
-            r = SDL_SetTextureBlendMode(self.lights[lid].lightmap.texture, SDL_BLENDMODE_ADD)
-        if r < 0:
-            self.driftwood.log.msg("ERROR", "Light", "insert", "SDL", SDL_GetError())
+            blendmode = SDL_BLENDMODE_BLEND
 
         # Give the light color.
-        r = SDL_SetTextureColorMod(self.lights[lid].lightmap.texture, int(color[0:2], 16), int(color[2:4], 16),
-                                   int(color[4:6], 16))
-        if r < 0:
-            self.driftwood.log.msg("ERROR", "Light", "insert", "SDL", SDL_GetError())
+        colormod = (
+            int(color[0:2], 16),
+            int(color[2:4], 16),
+            int(color[4:6], 16)
+        )
 
-        # Give the light transparency.
-        r = SDL_SetTextureAlphaMod(self.lights[lid].lightmap.texture, int(color[6:8], 16))
-        if r < 0:
-            self.driftwood.log.msg("ERROR", "Light", "insert", "SDL", SDL_GetError())
+        # Assign the light to its light id in the dictionary.
+        self.lights[lid] = light.Light(self, lid, lightmap, layer, x, y, w, h, alpha, blendmode, colormod, entity,
+                                       layermod)
 
         # We are done.
         self.driftwood.log.info("Light", "inserted", "{0} on layer {1} at position {2}, {3}".format(filename, layer,

--- a/src/stdlib/light.py
+++ b/src/stdlib/light.py
@@ -73,9 +73,12 @@ def color(lid, c):
     returns:
         True
     """
-    Driftwood.light.light(lid).color = c
-    SDL_SetTextureColorMod(Driftwood.light.light(lid).lightmap.texture, int(c[0:2], 16), int(c[2:4], 16),
-                           int(c[4:6], 16))
+    modcolor = (
+        int(c[0:2], 16),
+        int(c[2:4], 16),
+        int(c[4:6], 16)
+    )
+    Driftwood.light.light(lid).colormod = colormod
     alpha(lid, int(c[6:8], 16))
     return True
 
@@ -90,8 +93,7 @@ def alpha(lid, a):
     returns:
         True
     """
-    Driftwood.light.light(lid).color = Driftwood.light.light(lid).color[6:8] + '%02X' % a
-    SDL_SetTextureAlphaMod(Driftwood.light.light(lid).lightmap.texture, a)
+    Driftwood.light.light(lid).alpha = a
     return True
 
 
@@ -110,7 +112,7 @@ def flicker(lid, rx, ry, ralpha, rate, duration=None):
     """
     ox = Driftwood.light.light(lid).x
     oy = Driftwood.light.light(lid).y
-    oalpha = int(Driftwood.light.light(lid).color[6:], 16)
+    oalpha = Driftwood.light.light(lid).alpha
 
     fc = Driftwood.script.module("stdlib/helper.py").copy_function(__flicker_callback)
     fc.active = True
@@ -146,8 +148,7 @@ def __flicker_callback(seconds_past, msg):
         oalpha = 0
     Driftwood.light.light(lid).x = ox
     Driftwood.light.light(lid).y = oy
-    Driftwood.light.light(lid).color = Driftwood.light.light(lid).color[6:8] + '%02X' % oalpha
-    SDL_SetTextureAlphaMod(Driftwood.light.light(lid).lightmap.texture, oalpha)
+    Driftwood.light.light(lid).alpha = oalpha
     Driftwood.area.changed = True
 
 
@@ -162,10 +163,7 @@ def __end_flicker(seconds_past, msg):
 
         Driftwood.light.light(lid).x = Driftwood.vars["stdlib_light_flicker_originals"+str(lid)][0]
         Driftwood.light.light(lid).y = Driftwood.vars["stdlib_light_flicker_originals"+str(lid)][1]
-        Driftwood.light.light(lid).color = Driftwood.light.light(lid).color[6:8] + \
-            '%02X' % Driftwood.vars["stdlib_light_flicker_originals"+str(lid)][2]
-        SDL_SetTextureAlphaMod(Driftwood.light.light(lid).lightmap.texture,
-                               Driftwood.vars["stdlib_light_flicker_originals"+str(lid)][2])
+        Driftwood.light.light(lid).alpha = Driftwood.vars["stdlib_light_flicker_originals"+str(lid)][2]
         Driftwood.area.changed = True
 
 


### PR DESCRIPTION
Fixes lights which were broken in #114.

Related to, but does not close #117.

Changes:

- Allow FrameManager.copy() to take optional alpha, blendmode, and colormod parameters, which get applied to the source texture before being copied. Lights have been updated to use this.
- Allows lights to retain their prior functionality without needing to copy textures.

CPU usage on blue1 not changed. CPU usage on blue2 is ~5% higher than it was prior to #114.