### PR TITLE
Get ready to rummmmmmmmmbllllllllllle!

### DIFF
--- a/data/test/blue1.py
+++ b/data/test/blue1.py
@@ -1,9 +1,8 @@
 def setup():
     a = Driftwood.light.insert("lightmap_vertical1.png", 2, 2, 80, 50, 160, "000000FF", blend=True)
     b = Driftwood.light.insert("lightmap_vertical1.png", 2, 158, 80, 50, 160, "000000FF", blend=True)
-    if "got_blue_pearl" in Driftwood.database and "end_rumble" in Driftwood.vars and Driftwood.vars["end_rumble"]:
+    if "got_blue_pearl" in Driftwood.database:
         Driftwood.script.call("stdlib/viewport.py", "end_rumble")
-        Driftwood.vars["end_rumble"] = "true"
         Driftwood.script.call("stdlib/viewport.py", "rumble", 10, 3, None)
 
     h = Driftwood.widget.container(x=-1, y=-1, width=80, height=80)

--- a/data/test/blue1.py
+++ b/data/test/blue1.py
@@ -1,9 +1,12 @@
 def setup():
     a = Driftwood.light.insert("lightmap_vertical1.png", 2, 2, 80, 50, 160, "000000FF", blend=True)
     b = Driftwood.light.insert("lightmap_vertical1.png", 2, 158, 80, 50, 160, "000000FF", blend=True)
-    if "got_blue_pearl" in Driftwood.database:
-        Driftwood.script.call("stdlib/viewport.py", "end_rumble")
-        Driftwood.script.call("stdlib/viewport.py", "rumble", 10, 3, None)
+
+    # Prepare earthquake.
+    if "got_blue_pearl" not in Driftwood.database:
+        Driftwood.script.call("rumble.py", "regular_rumble", 15, 3, 5, 10)
+    else:
+        Driftwood.script.call("rumble.py", "constant_rumble", 10, 3)
 
     h = Driftwood.widget.container(x=-1, y=-1, width=80, height=80)
     Driftwood.widget.text("Test Text", "pf_arma_five.ttf", 16, parent=h,

--- a/data/test/blue2.py
+++ b/data/test/blue2.py
@@ -8,9 +8,7 @@ def lights():
         Driftwood.script.call("stdlib/light.py", "flicker", c.lid, 0, 0, 64, 16)
 
     else:
-        if "end_rumble" in Driftwood.vars and Driftwood.vars["end_rumble"]:
-            Driftwood.script.call("stdlib/viewport.py", "end_rumble")
-        Driftwood.vars["end_rumble"] = "true"
+        Driftwood.script.call("stdlib/viewport.py", "end_rumble")
         Driftwood.script.call("stdlib/viewport.py", "rumble", 30, 2, None)
         Driftwood.light.reset()
         a = Driftwood.light.insert("lightmap_circle1.png", 2, 80, 56, 160, 160, "FFFFFFFF", blend=False)

--- a/data/test/blue2.py
+++ b/data/test/blue2.py
@@ -8,8 +8,7 @@ def lights():
         Driftwood.script.call("stdlib/light.py", "flicker", c.lid, 0, 0, 64, 16)
 
     else:
-        Driftwood.script.call("stdlib/viewport.py", "end_rumble")
-        Driftwood.script.call("stdlib/viewport.py", "rumble", 30, 2, None)
+        Driftwood.script.call("rumble.py", "constant_rumble", 30, 2)
         Driftwood.light.reset()
         a = Driftwood.light.insert("lightmap_circle1.png", 2, 80, 56, 160, 160, "FFFFFFFF", blend=False)
         c = Driftwood.light.insert("lightmap_circle1.png", 3, 80, 56, 100, 100, "8888FFFF", blend=False)

--- a/data/test/house.py
+++ b/data/test/house.py
@@ -6,8 +6,6 @@ def open_door():
 
 
 def focus():
-    if Driftwood.tick.registered(Driftwood.vars["init_rumble_tick_callback"]):
-        Driftwood.tick.unregister(Driftwood.vars["init_rumble_tick_callback"])
     a = Driftwood.light.insert("lightmap_circle1.png", 2, 7, 115, 32, 32, "FFCC4466")
     b = Driftwood.light.insert("lightmap_circle1.png", 2, 153, 115, 32, 32, "FFCC4466")
     c = Driftwood.light.insert("lightmap_circle1.png", 2, 40, 7, 32, 32, "FFCC4466")

--- a/data/test/init.py
+++ b/data/test/init.py
@@ -18,7 +18,6 @@ def init():
         Driftwood.tick.register(rumble, delay=10.0)
     else:
         Driftwood.script.call("stdlib/viewport.py", "rumble", 12, 3, None)
-    Driftwood.vars["end_rumble"] = "true"
 
 
 def rumble():

--- a/data/test/init.py
+++ b/data/test/init.py
@@ -12,17 +12,3 @@ def init():
 
     # Insert the player entity.
     player = Driftwood.entity.insert("player.json", layer=1, x=16*4, y=16*8)
-
-    # Prepare earthquake.
-    if "got_blue_pearl" not in Driftwood.database:
-        Driftwood.tick.register(rumble, delay=10.0)
-    else:
-        Driftwood.script.call("stdlib/viewport.py", "rumble", 12, 3, None)
-
-
-def rumble():
-    Driftwood.script.call("stdlib/viewport.py", "rumble", 15, 3, 5)
-
-
-def end_rumble():
-    Driftwood.tick.unregister(rumble)

--- a/data/test/ring7.py
+++ b/data/test/ring7.py
@@ -1,5 +1,5 @@
 def kill_door():
-    Driftwood.script.call("stdlib/viewport.py", "end_rumble")
+    Driftwood.script.call("rumble.py", "end_rumble")
     Driftwood.tick.register(kill_door_callback1, once=True, delay=1.0)
     Driftwood.tick.register(kill_door_callback2, once=True, delay=2.0)
     Driftwood.tick.register(kill_door_callback3, once=True, delay=3.0)

--- a/data/test/rumble.py
+++ b/data/test/rumble.py
@@ -1,0 +1,27 @@
+def rumble(rate, intensity, duration):
+    __end_regular_rumble()
+    Driftwood.script.call("stdlib/viewport.py", "rumble", rate, intensity, duration)
+
+
+def regular_rumble(rate, intensity, duration, interval):
+    __end_regular_rumble()
+    def rumble():
+        Driftwood.script.call("stdlib/viewport.py", "rumble", rate, intensity, duration)
+    Driftwood.vars["regular_rumble"] = rumble
+    Driftwood.tick.register(rumble, delay=interval)
+
+
+def __end_regular_rumble():
+    if "regular_rumble" in Driftwood.vars:
+        Driftwood.tick.unregister(Driftwood.vars["regular_rumble"])
+        del Driftwood.vars["regular_rumble"]
+
+
+def constant_rumble(rate, intensity):
+    __end_regular_rumble()
+    Driftwood.script.call("stdlib/viewport.py", "rumble", rate, intensity, None)
+
+
+def end_rumble():
+    __end_regular_rumble()
+    Driftwood.script.call("stdlib/viewport.py", "end_rumble")

--- a/src/stdlib/viewport.py
+++ b/src/stdlib/viewport.py
@@ -1,7 +1,7 @@
 ####################################
 # Driftwood 2D Game Dev. Suite     #
 # stdlib/viewport.py               #
-# Copyright 2016 Michael D. Reiley #
+# Copyright 2017 Michael D. Reiley #
 # & Paul Merrill                   #
 ####################################
 
@@ -55,9 +55,15 @@ def rumble(rate, intensity, duration=None):
     Returns:
         Function to end the rumble.
     """
+    end_rumble()
+    __cancel_end_rumble_tick()
+
     Driftwood.tick.register(__rumble_callback, delay=1.0/rate, message=intensity)
+    Driftwood.vars["rumbling"] = True
+
     if duration:
-        Driftwood.tick.register(end_rumble, delay=duration, once=True)
+        Driftwood.tick.register(__end_rumble_tick, delay=duration, once=True)
+        Driftwood.vars["will_end_rumbling"] = True
 
 
 def __rumble_callback(seconds_past, intensity):
@@ -69,6 +75,19 @@ def __rumble_callback(seconds_past, intensity):
 
 
 def end_rumble():
-    Driftwood.tick.unregister(__rumble_callback)
-    Driftwood.area.offset = [0, 0]
-    Driftwood.area.changed = True
+    if "rumbling" in Driftwood.vars and Driftwood.vars["rumbling"]:
+        Driftwood.tick.unregister(__rumble_callback)
+        Driftwood.area.offset = [0, 0]
+        Driftwood.area.changed = True
+        Driftwood.vars["rumbling"] = False
+
+
+def __end_rumble_tick():
+    end_rumble()
+    Driftwood.vars["will_end_rumbling"] = False
+
+
+def __cancel_end_rumble_tick():
+    if "will_end_rumbling" in Driftwood.vars and Driftwood.vars["will_end_rumbling"]:
+        Driftwood.tick.unregister(__end_rumble_tick)
+        Driftwood.vars["will_end_rumbling"] = False


### PR DESCRIPTION
Fixes #104.

- On setup, blue1 will initiate a regular rumble or a medium constant rumble, depending on whether you've got the blue pearl.
- On setup, blue2 will initiate a heavy constant rumble if the blue pearl is already activated.
- When the blue pearl activates, blue2 initiates a heavy constant rumble.
- Ring7 stops all regular and constant rumbles.
- When one type of rumble begins, the others stop.
- The types of rumbling are automatically managed, taking the burden off the area scripts.

This means once you step outside the house with the blue pearl, you enter into a medium constant rumble.

Also, if you activate the blue pearl, then step down to blue1, your rumble will go down from a heavy constant rumble to a medium constant rumble. It will resume back to a heavy constant rumble when you return to blue2. This gives the player a sense of energy while in blue2.

Not sure about having the energy return to medium when stepping into blue1. But it does give a funny effect. Try it out.