### PR TITLE
Add global event handlers

### DIFF
--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -85,6 +85,9 @@ class AreaManager:
             # We have moved areas.
             self.refocused = True
 
+            # Call world's global on_focus handlers.
+            self.driftwood.script._call_global_triggers("on_focus")
+
             # If there is an on_focus function defined for this map, call it.
             if "on_focus" in self.tilemap.properties:
                 args = self.tilemap.properties["on_focus"].split(',')
@@ -101,8 +104,12 @@ class AreaManager:
             return False
 
     def _blur(self):
-        """If there is an on_blur function defined for this map, call it. This is called when we leave an area.
+        """Call the global on_blur functions, and call the map's on_blur, if it has one. This is called when we leave
+        an area.
         """
+        # Call the world's global on_blur handlers.
+        self.driftwood.script._call_global_triggers("on_blur")
+
         if "on_blur" in self.tilemap.properties:
             args = self.tilemap.properties["on_blur"].split(',')
             if len(args) < 2:

--- a/src/entity.py
+++ b/src/entity.py
@@ -272,6 +272,9 @@ class Entity:
     def _do_exit(self):
         """Perform an exit to another area.
         """
+        # Call world's global on_exit handlers.
+        self.manager.driftwood.script._call_global_triggers("on_exit")
+
         # Call the on_exit event if set.
         if "on_exit" in self.manager.driftwood.area.tilemap.properties:
             args = self.manager.driftwood.area.tilemap.properties["on_exit"].split(',')

--- a/src/tilemap.py
+++ b/src/tilemap.py
@@ -122,6 +122,9 @@ class Tilemap:
 
         self.__expand_properties()
 
+        # Call world's global on_enter handlers.
+        self.driftwood.script._call_global_triggers("on_load")
+
         # Call the on_enter event if set.
         if "on_load" in self.properties:
             self.driftwood.script.call(*self.properties["on_load"].split(','))

--- a/src/tilemap.py
+++ b/src/tilemap.py
@@ -123,11 +123,11 @@ class Tilemap:
         self.__expand_properties()
 
         # Call world's global on_enter handlers.
-        self.driftwood.script._call_global_triggers("on_load")
+        self.driftwood.script._call_global_triggers("on_enter")
 
         # Call the on_enter event if set.
-        if "on_load" in self.properties:
-            self.driftwood.script.call(*self.properties["on_load"].split(','))
+        if "on_enter" in self.properties:
+            self.driftwood.script.call(*self.properties["on_enter"].split(','))
 
         # Set the window title.
         if "title" in self.properties:


### PR DESCRIPTION
Fixes #132.

Limited to just "area" events for now... "tile" and "entity" events not included.

The global event handlers get called before map-specific event scripts are called.

They take no arguments. (They are nullary.) This can change to where they take some parameters if we want to start passing information later.