### PR TITLE
Type annotations throughout the engine for PyCharm

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -60,23 +60,7 @@ if __name__ == "__main__":
         print("[0] FATAL: jsonschema required, module \"jsonschema\" not found")
         sys.exit(1)  # Fail.
 
-# Import manager classes.
-from configmanager import ConfigManager
-from logmanager import LogManager
-from tickmanager import TickManager
-from databasemanager import DatabaseManager
-from pathmanager import PathManager
-from cachemanager import CacheManager
-from resourcemanager import ResourceManager
-from inputmanager import InputManager
-from windowmanager import WindowManager
-from framemanager import FrameManager
-from entitymanager import EntityManager
-from lightmanager import LightManager
-from areamanager import AreaManager
-from audiomanager import AudioManager
-from widgetmanager import WidgetManager
-from scriptmanager import ScriptManager
+from typing import Any, List, Union
 
 
 class _Driftwood:
@@ -145,13 +129,13 @@ class _Driftwood:
         if self.config["window"]["maxfps"] < 10:
             self.log.msg("WARNING", "Driftwood", "Very low fps values may cause unexpected behavior")
 
-    def _console(self, evtype):
+    def _console(self, evtype: int) -> None:
         """Drop to a pdb console if the console key is pressed.
         """
         if evtype is self.input.ONDOWN:
             pdb.set_trace()
 
-    def _run(self):
+    def _run(self) -> int:
         """Perform startup procedures and enter the mainloop.
         """
         # Only run if not already running.
@@ -200,7 +184,7 @@ class _Driftwood:
             self._terminate()
             return 0
 
-    def __handle_pause(self, keyevent):
+    def __handle_pause(self, keyevent: int) -> None:
         """Check if we are shutting down, otherwise just pause.
         """
         if keyevent == InputManager.ONDOWN:
@@ -211,7 +195,7 @@ class _Driftwood:
             else:
                 self.tick.toggle_pause()
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before shutdown. Here we tell all the relevant parts of the engine to free their resources
         before being deleted. We do this because Python's __del__ method is nearly useless as a destructor and we
         are using C constructs that need to be freed manually.
@@ -234,7 +218,7 @@ class CheckFailure(Exception):
     pass
 
 
-def _check(item, _type, _min=None, _max=None, _equals=None):
+def CHECK(item: Any, _type: Union[type, List[type]], _min: float=None, _max: float=None, _equals: float=None) -> bool:
     """Check if an input matches type, min, max, and/or equality requirements.
     
     This function belongs to the global scope as CHECK().
@@ -266,7 +250,7 @@ def _check(item, _type, _min=None, _max=None, _equals=None):
                                                                                                      _type))
 
     # Type check.
-    if type(item) is not _type and (type(_type) in [list, tuple] and type(item) not in _type):
+    if type(item) is not _type and (type(_type) is list and type(item) not in _type):
         print(type(item) in _type)
         raise CheckFailure("input failed type check: {0}: expected {1} instead".format(type(item), _type))
 
@@ -353,10 +337,29 @@ def _check(item, _type, _min=None, _max=None, _equals=None):
     return True
 
 
+# Import manager classes.
+from configmanager import ConfigManager
+from logmanager import LogManager
+from tickmanager import TickManager
+from databasemanager import DatabaseManager
+from pathmanager import PathManager
+from cachemanager import CacheManager
+from resourcemanager import ResourceManager
+from inputmanager import InputManager
+from windowmanager import WindowManager
+from framemanager import FrameManager
+from entitymanager import EntityManager
+from lightmanager import LightManager
+from areamanager import AreaManager
+from audiomanager import AudioManager
+from widgetmanager import WidgetManager
+from scriptmanager import ScriptManager
+
+
 if __name__ == "__main__":
     # Place certain items in the global scope.
     import builtins
-    builtins.CHECK = _check
+    builtins.CHECK = CHECK
     builtins.CheckFailure = CheckFailure
 
     # Set up the entry point.

--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -28,6 +28,7 @@
 
 from sdl2 import *
 
+from __main__ import _Driftwood, CHECK, CheckFailure
 import tilemap
 
 
@@ -45,7 +46,7 @@ class AreaManager:
         refocused: Whether we have gone to a new area since last checked.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """AreaManager class initializer.
 
         Args:
@@ -61,11 +62,11 @@ class AreaManager:
 
         self.driftwood.tick.register(self._tick)
 
-    def register(self):
+    def register(self) -> None:
         """Register our tick callback."""
         self.driftwood.tick.register(self._tick)
 
-    def focus(self, filename):
+    def focus(self, filename: str) -> bool:
         """Load and make active a new area.
 
         Args:
@@ -114,7 +115,7 @@ class AreaManager:
             self.driftwood.log.msg("ERROR", "Area", "focus", "could not load area", filename)
             return False
 
-    def _blur(self):
+    def _blur(self) -> None:
         """Call the global on_blur functions, and call the map's on_blur, if it has one. This is called when we leave
         an area.
         """
@@ -130,7 +131,7 @@ class AreaManager:
             self.driftwood.script.call(*args)
         self.tilemap = None
 
-    def _tick(self, seconds_past):
+    def _tick(self, seconds_past: float) -> None:
         """Tick callback.
         """
         if self.changed:  # TODO: Only redraw portions that have changed.
@@ -143,7 +144,7 @@ class AreaManager:
             self.__build_frame()
             self.changed = False
 
-    def __build_frame(self):
+    def __build_frame(self) -> None:
         """Build the frame and pass to WindowManager.
 
         For every tile and entity in each layer, copy its graphic onto the frame, then give the frame to WindowManager
@@ -204,8 +205,10 @@ class AreaManager:
                     # Clip entities so they don't appear outside the area.
                     clip_left = 0 if arearect[0] <= dstrect[0] else arearect[0] - dstrect[0]
                     clip_top = 0 if arearect[1] <= dstrect[1] else arearect[1] - dstrect[1]
-                    clip_right = 0 if dstrect[0] + dstrect[2] <= arearect[2] else (dstrect[0] + dstrect[2]) - arearect[2]
-                    clip_bot = 0 if dstrect[1] + dstrect[3] <= arearect[3] else (dstrect[1] + dstrect[3]) - arearect[3]
+                    clip_right = 0 if dstrect[0] + dstrect[2] <= arearect[2] \
+                        else (dstrect[0] + dstrect[2]) - arearect[2]
+                    clip_bot = 0 if dstrect[1] + dstrect[3] <= arearect[3] \
+                        else (dstrect[1] + dstrect[3]) - arearect[3]
 
                     srcrect[0] += clip_left
                     dstrect[0] += clip_left
@@ -234,8 +237,10 @@ class AreaManager:
                         # Clip entities so they don't appear outside the area.
                         clip_left = 0 if arearect[0] <= dstrect[0] else arearect[0] - dstrect[0]
                         clip_top = 0 if arearect[1] <= dstrect[1] else arearect[1] - dstrect[1]
-                        clip_right = 0 if dstrect[0] + dstrect[2] <= arearect[2] else (dstrect[0] + dstrect[2]) - arearect[2]
-                        clip_bot = 0 if dstrect[1] + dstrect[3] <= arearect[3] else (dstrect[1] + dstrect[3]) - arearect[3]
+                        clip_right = 0 if dstrect[0] + dstrect[2] <= arearect[2] \
+                            else (dstrect[0] + dstrect[2]) - arearect[2]
+                        clip_bot = 0 if dstrect[1] + dstrect[3] <= arearect[3] \
+                            else (dstrect[1] + dstrect[3]) - arearect[3]
 
                         srcrect[0] += clip_left
                         dstrect[0] += clip_left

--- a/src/audiomanager.py
+++ b/src/audiomanager.py
@@ -28,7 +28,10 @@
 # A big thank-you to Lazy Foo's SDL_Audio tutorial. It would've taken me a lot longer to build this without such clear
 # instruction. Link: <http://lazyfoo.net/SDL_tutorials/lesson11/>
 
+from typing import Optional
 from sdl2.sdlmixer import *
+
+from __main__ import _Driftwood, CHECK, CheckFailure
 
 
 class AudioManager:
@@ -42,7 +45,7 @@ class AudioManager:
             playing_sfx: Whether we are currently playing sfx or not.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         self.driftwood = driftwood
 
         self.playing_music = False
@@ -72,7 +75,7 @@ class AudioManager:
 
         # Did we succeed?
         if Mix_Init(init_flags) & init_flags != init_flags:
-            self.driftwood.log.msg("ERROR", "Audio", "__init__","failed to initialize audio format support",
+            self.driftwood.log.msg("ERROR", "Audio", "__init__", "failed to initialize audio format support",
                                    str(Mix_GetError()))
         else:
             self.driftwood.log.info("Audio", "initialized mixer audio format support",
@@ -82,7 +85,7 @@ class AudioManager:
         # Register the cleanup function.
         self.driftwood.tick.register(self._cleanup, delay=0.01, during_pause=True)
 
-    def play_sfx(self, filename, volume=None, loop=0, fade=0.0):
+    def play_sfx(self, filename: str, volume: int=None, loop: int=0, fade: float=0.0) -> Optional[int]:
         """Load and play a sound effect from an audio file.
 
         Args:
@@ -111,8 +114,11 @@ class AudioManager:
             return None
 
         # Load the sound effect.
-        sfx_temp = [filename, None]
-        sfx_temp[1] = self.driftwood.resource.request_audio(filename, False)
+        sfx_temp = [
+            filename,
+            self.driftwood.resource.request_audio(filename, False)
+        ]
+
         if not sfx_temp[1]:
             self.driftwood.log.msg("ERROR", "Audio", "play_sfx", "could not load sfx", filename)
             return None
@@ -145,7 +151,7 @@ class AudioManager:
 
         return channel
 
-    def volume_sfx(self, channel, volume=None):
+    def volume_sfx(self, channel: int, volume: int=None) -> Optional[int]:
         """Get or adjust the volume of a sound effect channel.
 
         Args:
@@ -185,7 +191,7 @@ class AudioManager:
                                channel)
         return None
 
-    def volume_sfx_by_filename(self, filename, volume=None):
+    def volume_sfx_by_filename(self, filename: str, volume: int=None) -> Optional[int]:
         """Get or adjust the volume of all currently playing instances of the named sound effect.
 
         Args:
@@ -229,7 +235,7 @@ class AudioManager:
                                "cannot adjust volume for nonexistent instances of sfx", filename)
         return None
 
-    def stop_sfx(self, channel, fade=0.0):
+    def stop_sfx(self, channel: int, fade: float=0.0) -> bool:
         """Stop a sound effect. Requires the sound effect's channel number from play_sfx()'s return code.
 
         Args:
@@ -261,7 +267,7 @@ class AudioManager:
                                channel)
         return False
 
-    def stop_sfx_by_filename(self, filename, fade=0.0):
+    def stop_sfx_by_filename(self, filename: str, fade: float=0.0) -> bool:
         """Stop all currently playing instances of the named sound effect.
 
         Args:
@@ -296,7 +302,7 @@ class AudioManager:
                                filename)
         return False
 
-    def stop_all_sfx(self):
+    def stop_all_sfx(self) -> bool:
         """Stop all currently playing sound effects.
 
         Returns:
@@ -307,7 +313,7 @@ class AudioManager:
         self.__sfx = {}
         return True
 
-    def play_music(self, filename, volume=None, loop=0, fade=0.0):
+    def play_music(self, filename: str, volume: int=None, loop: int=0, fade: float=0.0) -> bool:
         """Load and play music from an audio file. Also stops and unloads any previously loaded music.
 
         Args:
@@ -332,7 +338,7 @@ class AudioManager:
 
         # Give up if we didn't initialize properly.
         if 0 in self.__init_success:
-            self.driftwood.log.msg("WARNING", "Audio", "play_music","cannot play music due to initialization failure",
+            self.driftwood.log.msg("WARNING", "Audio", "play_music", "cannot play music due to initialization failure",
                                    filename)
             return False
 
@@ -356,7 +362,7 @@ class AudioManager:
 
         if result == -1:
             self.driftwood.log.msg("WARNING", "Audio", "play_music", "could not play music")
-            return
+            return False
 
         if volume is not None:
             # Keep volume within bounds.
@@ -376,7 +382,7 @@ class AudioManager:
 
         return True
 
-    def volume_music(self, volume=None):
+    def volume_music(self, volume: int=None) -> Optional[int]:
         """Get or adjust the volume of the currently playing music.
 
         Args:
@@ -413,7 +419,7 @@ class AudioManager:
         self.driftwood.log.msg("WARNING", "Audio", "volume_music", "cannot adjust volume for nonexistent music")
         return None
 
-    def stop_music(self, fade=0.0):
+    def stop_music(self, fade: float=0.0) -> bool:
         """Stop and unload any currently loaded music.
 
         Args:
@@ -443,7 +449,7 @@ class AudioManager:
 
         return True
 
-    def _cleanup(self, seconds_past):
+    def _cleanup(self, seconds_past: float) -> None:
         # Tick callback to clean up files we're done with.
         if self.__music and not Mix_PlayingMusic():
             self.__music = None
@@ -458,7 +464,7 @@ class AudioManager:
         except RuntimeError:
             pass
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Prepare for shutdown.
         """
         self.stop_music()

--- a/src/cachemanager.py
+++ b/src/cachemanager.py
@@ -27,6 +27,9 @@
 # **********
 
 import gc
+from typing import Any, KeysView, Optional
+
+from __main__ import _Driftwood, CHECK, CheckFailure
 
 
 class CacheManager:
@@ -39,7 +42,7 @@ class CacheManager:
         driftwood: Base class instance.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """CacheManager class initializer.
 
         Args:
@@ -54,19 +57,19 @@ class CacheManager:
         # Register the tick callback.
         self.driftwood.tick.register(self._tick, delay=float(self.driftwood.config["cache"]["ttl"]))
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         return item in self.__cache
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Any:
         return self.download(item)
 
-    def __delitem__(self, item):
+    def __delitem__(self, item: str) -> None:
         self.purge(item)
 
-    def __iter__(self):
+    def __iter__(self) -> KeysView:
         return self.__cache.keys()
 
-    def upload(self, filename, contents, keep_for_ttl=True):
+    def upload(self, filename: str, contents: Any, keep_for_ttl: bool=True) -> bool:
         """Upload a file into the cache.
 
         Args:
@@ -98,7 +101,7 @@ class CacheManager:
 
         return True
 
-    def download(self, filename):
+    def download(self, filename: str) -> Any:
         """Download a file from the cache if present, and update the timestamp.
 
         Args:
@@ -122,7 +125,7 @@ class CacheManager:
 
         return None
 
-    def purge(self, filename):
+    def purge(self, filename: str) -> Optional[bool]:
         """Purge a file from the cache.
 
         Args:
@@ -153,7 +156,7 @@ class CacheManager:
 
         return True
 
-    def flush(self):
+    def flush(self) -> bool:
         """Empty the cache.
 
         Returns:
@@ -165,7 +168,7 @@ class CacheManager:
 
         return True
 
-    def clean(self):
+    def clean(self) -> bool:
         """Perform garbage collection on expired files.
 
         Returns:
@@ -199,7 +202,7 @@ class CacheManager:
 
         return True
 
-    def _reverse_purge(self, inst):
+    def _reverse_purge(self, inst: Any) -> None:
         """Purge an item from the cache by checking if the passed instance is cached, rather than searching by
         filename.
         """
@@ -209,7 +212,7 @@ class CacheManager:
                 self.driftwood.log.info("Cache", "reverse-purged", items)
                 break
 
-    def _tick(self, seconds_past):
+    def _tick(self, seconds_past: float) -> None:
         self.__now += seconds_past
 
         self.clean()

--- a/src/configmanager.py
+++ b/src/configmanager.py
@@ -32,7 +32,10 @@ import jsonschema
 import os
 import sys
 import traceback
+from typing import Any, ItemsView
 import zipfile
+
+from __main__ import _Driftwood
 
 VERSION = "Driftwood 2D Alpha-0.0.7"
 COPYRIGHT = "Copyright 2016-2017 Michael D. Reiley and Paul Merrill"
@@ -50,7 +53,7 @@ class ConfigManager:
         driftwood: Base class instance.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """ConfigManager class initializer.
 
         Args:
@@ -65,22 +68,22 @@ class ConfigManager:
         self.__cmdline_args = self.__read_cmdline()
         self.__prepare_config()
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         if item in self.__config:
             return True
         return False
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Any:
         if self.__contains__(item):
             return self.__config[item]
         else:
             # This should be initialized by now.
             self.driftwood.log.msg("ERROR", "Config", "__getitem__", "no such entry", item)
 
-    def __iter__(self):
+    def __iter__(self) -> ItemsView:
         return self.__config.items()
 
-    def __read_cmdline(self):
+    def __read_cmdline(self) -> argparse.Namespace:
         """Read in command line options using ArgumentParser.
 
         Returns:
@@ -123,7 +126,7 @@ class ConfigManager:
 
         return parser.parse_args()
 
-    def __prepare_config(self):
+    def __prepare_config(self) -> None:
         """Prepare the configuration for use.
 
         Combine the command line arguments and the configuration file into the internal __config dictionary, favoring

--- a/src/databasemanager.py
+++ b/src/databasemanager.py
@@ -29,7 +29,10 @@
 import json
 import os
 import sys
+from typing import Any, Optional
 import zlib
+
+from __main__ import _Driftwood, CHECK, CheckFailure
 
 
 class DatabaseManager:
@@ -43,7 +46,7 @@ class DatabaseManager:
         filename: Filename of the database.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """DatabaseManager class initializer.
 
         Args:
@@ -70,21 +73,21 @@ class DatabaseManager:
 
         self.driftwood.tick.register(self._tick, during_pause=True)
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         if item in self.__database:
             return True
         return False
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Any:
         return self.get(item)
 
-    def __setitem__(self, item, obj):
+    def __setitem__(self, item: str, obj: Any) -> None:
         self.put(item, obj)
 
-    def __delitem__(self, item):
+    def __delitem__(self, item: str) -> None:
         self.remove(item)
 
-    def open(self, filename):
+    def open(self, filename: str) -> Optional[bool]:
         """Opens a new database and closes the current one.
         
         If opening the new database fails, the old one stays loaded.
@@ -124,7 +127,7 @@ class DatabaseManager:
         self.driftwood.log.info("Database", "open", self.filename)
         return True  # Success
 
-    def get(self, key):
+    def get(self, key: str) -> Any:
         """Get an object by key (name).
 
         Retrieve an object from the database by its key.
@@ -150,7 +153,7 @@ class DatabaseManager:
             self.driftwood.log.msg("ERROR", "Database", "get", "no such key", "\"{0}\"".format(key))
             return None
 
-    def put(self, key, obj):
+    def put(self, key: str, obj: Any) -> Optional[bool]:
         """Put an object by key (name).
 
         Create or update a key with a new object.
@@ -180,7 +183,7 @@ class DatabaseManager:
         self.driftwood.log.info("Database", "put", "\"{0}\"".format(key))
         return True
 
-    def remove(self, key):
+    def remove(self, key: str) -> Optional[bool]:
         """Remove a key.
 
         Removes a key and its object from the database.
@@ -207,7 +210,7 @@ class DatabaseManager:
             self.driftwood.log.msg("ERROR", "Database", "remove", "no such key", "\"{0}\"".format(key))
             return False
 
-    def flush(self):
+    def flush(self) -> bool:
         """Force the database to write to disk now.
         
         Returns:
@@ -218,7 +221,7 @@ class DatabaseManager:
         self.driftwood.log.info("Database", "flush", self.filename)
         return True
 
-    def __test_db_dir(self):
+    def __test_db_dir(self) -> bool:
         """Test if we can create or open the database directory.
         """
         db_dir_path = self.driftwood.config["database"]["root"]
@@ -241,7 +244,7 @@ class DatabaseManager:
 
         return True
 
-    def __test_db_open(self):
+    def __test_db_open(self) -> bool:
         """Test if we can create or open the database file.
         """
         try:
@@ -250,7 +253,7 @@ class DatabaseManager:
         except:
             return False
 
-    def __load(self):
+    def __load(self) -> Optional[dict]:
         """Load the database file from disk.
         """
         if not self.__test_db_open():
@@ -266,7 +269,7 @@ class DatabaseManager:
         except:
             return None
 
-    def _tick(self, seconds_past):
+    def _tick(self, seconds_past: float) -> None:
         """Tick callback.
         
         If there have been any changes to the database in memory, write them to disk.
@@ -280,8 +283,8 @@ class DatabaseManager:
                 sys.exit(1)
             self.__changed = False
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         # Make sure we write to disk.
-        self._tick(None)
+        self._tick(0.0)

--- a/src/entitymanager.py
+++ b/src/entitymanager.py
@@ -30,7 +30,6 @@ import jsonschema
 import sys
 import traceback
 
-import entity
 from inputmanager import InputManager
 
 
@@ -341,3 +340,6 @@ class EntityManager:
             self.entities[entity]._terminate()
         self.entities = None
         self.spritesheets = None
+
+
+import entity

--- a/src/entitymanager.py
+++ b/src/entitymanager.py
@@ -29,8 +29,15 @@
 import jsonschema
 import sys
 import traceback
+from typing import ItemsView, List, Optional
 
-from inputmanager import InputManager
+from __main__ import _Driftwood, CHECK, CheckFailure
+import entity
+import spritesheet
+
+# Keep a reference to the entity module, which is overridden by the EntityManager.entity function later in the file.
+# It is only overridden while inside type annotations.
+_entity = entity
 
 
 class EntityManager:
@@ -48,7 +55,7 @@ class EntityManager:
         spritesheets: The dictionary of Spritesheet class instances for each sprite sheet. Sorted by filename.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """EntityManager class initializer.
 
         Args:
@@ -65,21 +72,21 @@ class EntityManager:
 
         self.__last_eid = -1
 
-    def __contains__(self, eid):
+    def __contains__(self, eid: int) -> bool:
         if self.entity(eid):
             return True
         return False
 
-    def __getitem__(self, eid):
+    def __getitem__(self, eid: int) -> Optional[entity.Entity]:
         return self.entity(eid)
 
-    def __delitem__(self, eid):
+    def __delitem__(self, eid: int) -> bool:
         return self.kill(eid)
 
-    def __iter__(self):
+    def __iter__(self) -> ItemsView:
         return self.entities.items()
 
-    def insert(self, filename, layer, x, y):
+    def insert(self, filename: str, layer: int, x: int, y: int) -> Optional[entity.Entity]:
         """Insert an entity at a position in the area.
 
         Args:
@@ -167,7 +174,7 @@ class EntityManager:
 
         return self.entities[eid]
 
-    def entity(self, eid):
+    def entity(self, eid: int) -> Optional[entity.Entity]:
         """Retrieve an entity by eid.
 
         Args:
@@ -187,7 +194,7 @@ class EntityManager:
 
         return None
 
-    def entity_at(self, x, y):
+    def entity_at(self, x: int, y: int) -> Optional[_entity.Entity]:
         """Retrieve an entity by pixel coordinate.
 
         Args:
@@ -209,7 +216,7 @@ class EntityManager:
                 return self.entities[eid]
         return None
 
-    def layer(self, layer):
+    def layer(self, layer: int) -> List[int]:
         """Retrieve a list of entities on a certain layer.
 
         Args:
@@ -233,7 +240,7 @@ class EntityManager:
         # Put them in order of eid so they don't switch around if we iterate them.
         return sorted(ents, key=lambda by_eid: by_eid.eid)
 
-    def kill(self, eid):
+    def kill(self, eid: int) -> bool:
         """Kill an entity by eid.
 
         Args:
@@ -261,7 +268,7 @@ class EntityManager:
         self.driftwood.log.msg("WARNING", "Entity", "kill", "attempt to kill nonexistent entity", eid)
         return False
 
-    def killall(self, filename):
+    def killall(self, filename: str) -> bool:
         """Kill all entities by filename.
 
         Args:
@@ -297,7 +304,7 @@ class EntityManager:
         self.driftwood.log.msg("WARNING", "Entity", "killall", "attempt to kill nonexistent entities", filename)
         return False
 
-    def spritesheet(self, filename):
+    def spritesheet(self, filename: spritesheet.Spritesheet) -> Optional[bool]:
         """Retrieve a sprite sheet by its filename.
 
         Args:
@@ -318,7 +325,7 @@ class EntityManager:
 
         return False
 
-    def collision(self, a, b):
+    def collision(self, a: _entity.Entity, b: _entity.Entity) -> bool:
         """Notify the collision callback, if set, that entity "a" has collided with entity or tile "b".
 
         Args:
@@ -333,13 +340,10 @@ class EntityManager:
 
         return True
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
-        for entity in self.entities:
-            self.entities[entity]._terminate()
+        for eid in self.entities:
+            self.entities[eid]._terminate()
         self.entities = None
         self.spritesheets = None
-
-
-import entity

--- a/src/filetype.py
+++ b/src/filetype.py
@@ -32,6 +32,8 @@ from sdl2.sdlimage import *
 from sdl2.sdlmixer import *
 from sdl2.sdlttf import *
 
+from __main__ import _Driftwood
+
 
 class AudioFile:
     """This class represents and abstracts a single OGG Vorbis audio file.
@@ -40,7 +42,7 @@ class AudioFile:
         audio: The SDL_mixer audio handle.
     """
 
-    def __init__(self, driftwood, data, music=False):
+    def __init__(self, driftwood: _Driftwood, data: bytes, music: bool=False):
         self.driftwood = driftwood
 
         self.audio = None
@@ -49,7 +51,7 @@ class AudioFile:
 
         self.__load(self.__data)
 
-    def __load(self, data):
+    def __load(self, data: bytes) -> None:
         """Load the audio data with SDL_Mixer.
         """
         if data:
@@ -61,7 +63,7 @@ class AudioFile:
             if not self.audio:
                 self.driftwood.log.msg("ERROR", "AudioFile", "__load", "SDL_Mixer", SDL_GetError())
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         if self.audio:
@@ -82,7 +84,7 @@ class FontFile:
         font: The SDL_ttf font handle.
         ptsize: The size of the font in pt.
     """
-    def __init__(self, driftwood, data, ptsize):
+    def __init__(self, driftwood: _Driftwood, data: bytes, ptsize: int):
         """FontFile class initializer.
         """
         self.driftwood = driftwood
@@ -93,7 +95,7 @@ class FontFile:
 
         self.__load(self.__data)
 
-    def __load(self, data):
+    def __load(self, data: bytes) -> None:
         """Load the font data with SDL_TTF.
         """
         if data:
@@ -101,7 +103,7 @@ class FontFile:
             if not self.font:
                 self.driftwood.log.msg("ERROR", "FontFile", "__load", "SDL_TTF", TTF_GetError())
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         if self.font:
@@ -119,7 +121,7 @@ class ImageFile:
         texture: An SDL texture containing the image.
     """
 
-    def __init__(self, driftwood, data, renderer):
+    def __init__(self, driftwood: _Driftwood, data: bytes, renderer: SDL_Renderer):
         """ImageFile class initializer.
         """
         self.driftwood = driftwood
@@ -136,7 +138,7 @@ class ImageFile:
         SDL_QueryTexture(self.texture, None, None, byref(tw), byref(th))
         self.width, self.height = tw.value, th.value
 
-    def __load(self, data):
+    def __load(self, data: bytes) -> None:
         """Load the image data with SDL_Image.
         """
         if data:
@@ -148,7 +150,7 @@ class ImageFile:
             if not self.texture:
                 self.driftwood.log.msg("ERROR", "ImageFile", "__load", "SDL_Image", IMG_GetError())
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         if not self.surface and not self.texture:

--- a/src/framemanager.py
+++ b/src/framemanager.py
@@ -27,9 +27,11 @@
 # **********
 
 from ctypes import byref
-from ctypes import c_int, c_ubyte
+from ctypes import c_ubyte
 from sdl2 import *
+from typing import List, Tuple, Union
 
+from __main__ import _Driftwood, CHECK, CheckFailure
 import filetype
 
 
@@ -47,7 +49,7 @@ class FrameManager:
         changed: Whether the frame has been changed. [STATE_NOTCHANGED, STATE_BACKBUFFER_NEEDS_UPDATE, STATE_CHANGED]
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """FrameManager class initializer.
 
         Initializes frame handling.
@@ -80,7 +82,7 @@ class FrameManager:
 
         self.changed = self.STATE_NOTCHANGED
 
-    def clear(self):
+    def clear(self) -> bool:
         """Clear the back buffer.
 
         Returns:
@@ -102,7 +104,7 @@ class FrameManager:
 
         return True
 
-    def prepare(self, width, height):
+    def prepare(self, width: int, height: int) -> bool:
         """Prepare and clear the back buffer.
 
         Set up our back buffer as a texture of the specified size. This also clears the back buffer.
@@ -137,7 +139,7 @@ class FrameManager:
 
         return True
 
-    def frame(self, tex=None):
+    def frame(self, tex: Union[SDL_Texture, filetype.ImageFile]=None) -> bool:
         """Replace the current frame with a texture or the internal back buffer, and adjust the viewport accordingly.
 
         Args:
@@ -250,7 +252,14 @@ class FrameManager:
 
         return True
 
-    def copy(self, tex, srcrect, dstrect, direct=False, alpha=None, blendmode=None, colormod=None):
+    def copy(self,
+             tex: SDL_Texture,
+             srcrect: List[int],
+             dstrect: List[int],
+             direct: bool=False,
+             alpha: int=None,
+             blendmode: int=None,
+             colormod: Tuple[int, int, int]=None) -> bool:
         """Copy a texture onto the back buffer.
         
         Copy the source rectangle from the texture tex to the destination rectangle in our back buffer.
@@ -275,7 +284,7 @@ class FrameManager:
                 CHECK(direct, bool)
             CHECK(alpha, int)
             CHECK(blendmode, int)
-            CHECK(colormod, int)
+            CHECK(colormod, list)
         except CheckFailure as e:
             self.driftwood.log.msg("ERROR", "Frame", "copy", "bad argument", e)
             return False
@@ -369,7 +378,7 @@ class FrameManager:
 
         return ret
 
-    def overlay(self, tex, srcrect, dstrect):
+    def overlay(self, tex: SDL_Texture, srcrect: List[int], dstrect: List[int]) -> bool:
         """Schedule to copy a texture directly onto the window, ignoring any frame or viewport calculations.
 
         Args:
@@ -394,7 +403,7 @@ class FrameManager:
 
         return True
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         if self.__frontbuffer:

--- a/src/inputmanager.py
+++ b/src/inputmanager.py
@@ -27,8 +27,11 @@
 # **********
 
 import types
+from typing import Callable, Optional, Union
 
 from sdl2 import SDL_GetKeyName
+
+from __main__ import _Driftwood, CHECK, CheckFailure
 
 
 class InputManager:
@@ -43,7 +46,7 @@ class InputManager:
 
     ONDOWN, ONREPEAT, ONUP = range(3)
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """InputManager class initializer.
 
         Args:
@@ -64,21 +67,18 @@ class InputManager:
         # Register the tick callback.
         self.driftwood.tick.register(self._tick, during_pause=True)
 
-    def __contains__(self, item):
+    def __contains__(self, item: int) -> bool:
         if item in self.__registry:
             return True
         return False
 
-    def __getitem__(self, item):
-        return self.__registry[item][0]
-
-    def __setitem__(self, item, value):
+    def __setitem__(self, item: Union[int, str], value: Callable) -> None:
         self.register(item, value)
 
-    def __delitem__(self, item):
+    def __delitem__(self, item: int) -> None:
         self.unregister(item)
 
-    def keyname(self, keysym):
+    def keyname(self, keysym: int) -> Optional[str]:
         """Return a string naming a keysym. The up arrow key returns "Up," etc.
 
         Args:
@@ -100,7 +100,7 @@ class InputManager:
         except:
             return None
 
-    def keysym(self, keyname):
+    def keysym(self, keyname: str) -> Optional[int]:
         """Return a keysym for the named keybinding.
 
         Args:
@@ -122,7 +122,12 @@ class InputManager:
         except:
             return None
 
-    def register(self, keyid, callback, throttle=0.0, delay=0.0, mod=False):
+    def register(self,
+                 keyid: Union[int, str],
+                 callback: Callable,
+                 throttle: float=0.0,
+                 delay: float=0.0,
+                 mod: bool=False) -> bool:
         """Register an input callback.
 
         The callback function will receive a call every tick that the key is on top of the input stack. (the key which
@@ -173,7 +178,7 @@ class InputManager:
 
         return True
 
-    def unregister(self, keysym):
+    def unregister(self, keysym: int) -> bool:
         """Unregister an input callback.
 
         Args:
@@ -198,7 +203,7 @@ class InputManager:
                                    self.keyname(keysym))
             return False
 
-    def pressed(self, keysym):
+    def pressed(self, keysym: int) -> bool:
         """Check if a key is currently being pressed.
 
         Args:
@@ -217,7 +222,7 @@ class InputManager:
 
         return False
 
-    def _key_down(self, keysym):
+    def _key_down(self, keysym: int) -> None:
         """Push a keypress onto the input stack if not present.
 
         Args:
@@ -235,7 +240,7 @@ class InputManager:
             # self.driftwood.log.msg("WARNING", "InputManager", "key_down", "key already down", self.keyname(keysym))
             pass
 
-    def _key_up(self, keysym):
+    def _key_up(self, keysym: int) -> None:
         """Remove a keypress from the input stack if present.
 
         Args:
@@ -255,7 +260,7 @@ class InputManager:
                 self.__registry[keysym]["repeats"] = 0
                 self.__registry[keysym]["callback"](InputManager.ONUP)
 
-    def _tick(self, seconds_past):
+    def _tick(self, seconds_past: float) -> None:
         """Tick callback.
 
         If there is a keypress on top of the stack and it maps to a callback in the registry, call it. Also pass the

--- a/src/layer.py
+++ b/src/layer.py
@@ -26,7 +26,11 @@
 # IN THE SOFTWARE.
 # **********
 
+from typing import Dict, Optional
+
+from __main__ import _Driftwood, CHECK, CheckFailure
 import tile
+import tilemap
 
 
 class Layer:
@@ -40,7 +44,7 @@ class Layer:
         tiles: The list of Tile class instances for each tile.
     """
 
-    def __init__(self, driftwood, tilemap, layerdata, zpos):
+    def __init__(self, driftwood: _Driftwood, tilemap: 'tilemap.Tilemap', layerdata: dict, zpos: int):
         """Layer class initializer.
 
         Args:
@@ -62,14 +66,14 @@ class Layer:
 
         self.__prepare_layer()
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int) -> '_AbstractColumn':
         return _AbstractColumn(self, item)
 
-    def clear(self):
+    def clear(self) -> None:
         for tile in self.tiles:
             tile.unregister()
 
-    def tile(self, x, y):
+    def tile(self, x: int, y: int) -> Optional['tile.Tile']:
         """Retrieve a tile from the layer by its coordinates.
 
         Args:
@@ -97,7 +101,7 @@ class Layer:
                                    "tried to lookup nonexistent tile at", "{0}x{1}".format(x, y))
             return None
 
-    def tile_index(self, x, y):
+    def tile_index(self, x: int, y: int) -> Optional[int]:
         """Retrieve the index of a tile in the tiles list so you can modify it.
 
         Args:
@@ -122,7 +126,7 @@ class Layer:
                                    "tried to lookup nonexistent tile at", "{0}x{1}".format(x, y))
             return None
 
-    def _process_objects(self, objdata):
+    def _process_objects(self, objdata: dict) -> None:
         """Process and merge an object layer into the tile layer below.
 
         This method is marked private even though it's called from Tilemap, because it should not be called outside the
@@ -212,7 +216,7 @@ class Layer:
                         args[3] = int(args[3])
                         self.driftwood.entity.insert(*args)
 
-    def __expand_properties(self, properties):
+    def __expand_properties(self, properties: Dict[str, str]) -> None:
         new_props = {}
         old_props = []
 
@@ -229,7 +233,7 @@ class Layer:
         for prop in old_props:
             del properties[prop]
 
-    def __prepare_layer(self):
+    def __prepare_layer(self) -> None:
         # Set layer properties if present.
         if "properties" in self.__layer:
             self.properties = self.__layer["properties"]
@@ -248,7 +252,7 @@ class Layer:
             else:
                 self.tiles.append(tile.Tile(self, seq, None, None))
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         for tile in self.tiles:
@@ -257,9 +261,9 @@ class Layer:
 
 
 class _AbstractColumn:
-    def __init__(self, layer, x):
+    def __init__(self, layer: Layer, x: int):
         self.__layer = layer
         self.__x = x
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int) -> Optional['tile.Tile']:
         return self.__layer.tile(self.__x, item)

--- a/src/light.py
+++ b/src/light.py
@@ -25,6 +25,12 @@
 # IN THE SOFTWARE.
 # **********
 
+from typing import Tuple
+
+import entity
+import filetype
+import lightmanager
+
 
 class Light:
     """This class represents a light.
@@ -32,7 +38,20 @@ class Light:
     Attributes:
         Same as __init__ args.
     """
-    def __init__(self, manager, lid, lightmap, layer, x, y, w, h, alpha, blendmode, colormod, entity, layermod):
+    def __init__(self,
+                 manager: 'lightmanager.LightManager',
+                 lid: int,
+                 lightmap: filetype.ImageFile,
+                 layer: int,
+                 x: int,
+                 y: int,
+                 w: int,
+                 h: int,
+                 alpha: int,
+                 blendmode: int,
+                 colormod: Tuple[int, int, int],
+                 entity: entity.Entity,
+                 layermod: int):
         """Light class initializer.
 
         Args:
@@ -66,9 +85,9 @@ class Light:
         self.entity = entity
 
         if entity is not None:
-            self.manager.driftwood.tick.register(self._track_entity, message=[entity, layermod])
+            self.manager.driftwood.tick.register(self._track_entity, message=(entity, layermod))
 
-    def _track_entity(self, seconds_past, msg):
+    def _track_entity(self, seconds_past: float, msg: Tuple[entity.Entity, int]) -> None:
         """Follow an entity's position.
         """
         try:  # Avoid strange timing anomaly.

--- a/src/lightmanager.py
+++ b/src/lightmanager.py
@@ -26,9 +26,16 @@
 # **********
 
 from sdl2 import *
+from typing import ItemsView, List, Optional
 
+from __main__ import _Driftwood, CHECK, CheckFailure
+import entity
 import filetype
 import light
+
+# Keep a reference to the light module, which is overridden by the LightManager.light function later in the file.
+# It is only overridden while inside type annotations.
+_light = light
 
 
 class LightManager:
@@ -42,7 +49,7 @@ class LightManager:
         lights: The dictionary of Light class instances for each light. Stored by lid.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """LightManager class initializer.
 
         Args:
@@ -54,21 +61,31 @@ class LightManager:
 
         self.__last_lid = -1
 
-    def __contains__(self, lid):
+    def __contains__(self, lid: int) -> bool:
         if self.light(lid):
             return True
         return False
 
-    def __getitem__(self, lid):
+    def __getitem__(self, lid) -> Optional[light.Light]:
         return self.light(lid)
 
-    def __delitem__(self, lid):
+    def __delitem__(self, lid) -> bool:
         return self.kill(lid)
 
-    def __iter__(self):
+    def __iter__(self) -> ItemsView:
         return self.lights.items()
 
-    def insert(self, filename, layer, x, y, w, h, color="FFFFFFFF", blend=False, entity=None, layermod=0):
+    def insert(self,
+               filename: str,
+               layer: int,
+               x: int,
+               y: int,
+               w: int,
+               h: int,
+               color: str="FFFFFFFF",
+               blend: bool=False,
+               entity: entity.Entity=None,
+               layermod=0) -> Optional[int]:
         """Create and insert a new light into the area.
 
         Args:
@@ -150,7 +167,7 @@ class LightManager:
 
         return self.lights[lid]
 
-    def light(self, lid):
+    def light(self, lid: int) -> Optional[light.Light]:
         """Retrieve a light by lid.
 
         Args:
@@ -169,7 +186,7 @@ class LightManager:
             return self.lights[lid]
         return None
 
-    def light_at(self, x, y):
+    def light_at(self, x: int, y: int) -> Optional[_light.Light]:
         """Retrieve a light by pixel coordinate.
 
         Args:
@@ -191,7 +208,7 @@ class LightManager:
                 return self.lights[lid]
         return None
 
-    def layer(self, l):
+    def layer(self, l: int) -> Optional[List[_light.Light]]:
         """Retrieve a list of lights on the specified layer.
 
         Args:
@@ -214,7 +231,7 @@ class LightManager:
 
         return lights
 
-    def entity(self, eid):
+    def entity(self, eid: int) -> Optional[_light.Light]:
         """Retrieve a light by the entity it is bound to.
 
         Args:
@@ -234,7 +251,7 @@ class LightManager:
                 return self.lights[lid]
         return None
 
-    def set_color(self, lid, color, blend=None):
+    def set_color(self, lid: int, color: str, blend: bool=None) -> bool:
         """Update the color, alpha, and blending of an existing light.
 
         Args:
@@ -296,7 +313,7 @@ class LightManager:
 
         return False
 
-    def kill(self, lid):
+    def kill(self, lid: int) -> bool:
         """Kill a light by lid.
 
         Args:
@@ -320,7 +337,7 @@ class LightManager:
         self.driftwood.log.msg("WARNING", "Light", "kill", "attempt to kill nonexistent light", lid)
         return False
 
-    def killall(self, file):
+    def killall(self, file: str) -> bool:
         """Kill all lights by filename or lightmap.
 
         Args:
@@ -362,7 +379,7 @@ class LightManager:
         self.driftwood.log.msg("WARNING", "Entity", "killall", "attempt to kill nonexistent lights", file)
         return False
 
-    def reset(self):
+    def reset(self) -> bool:
         """Reset the lights.
 
         Returns: True

--- a/src/logmanager.py
+++ b/src/logmanager.py
@@ -27,6 +27,9 @@
 # **********
 
 import sys
+from typing import Any, List
+
+from __main__ import _Driftwood
 
 
 class LogManager:
@@ -38,7 +41,7 @@ class LogManager:
         driftwood: Base class instance.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """LogManager class initializer.
 
         Args:
@@ -56,7 +59,7 @@ class LogManager:
                 self.__file = open(self.driftwood.config["log"]["file"], "a+")
                 self.__file.write("Starting up...\n")
 
-    def msg(self, *chain):
+    def msg(self, *chain: Any) -> bool:
         """Log a message.
 
         Args:
@@ -65,8 +68,15 @@ class LogManager:
         Returns:
             True if message was printed, false otherwise.
         """
+        chain = list(chain)
+
+        # Convert everything to strings.
+        for c in range(len(chain)):
+            if type(chain[c]) != str:
+                chain[c] = str(chain[c])
+
         if not self.__check_suppress(chain):
-            self.__print(list(chain))
+            self.__print(chain)
             # Die on non-info (error or warning) messages.
             if self.driftwood.config["log"]["halt"]:
                 # Or not if we suppressed halting on this message.
@@ -75,7 +85,7 @@ class LogManager:
             return True
         return False
 
-    def info(self, *chain):
+    def info(self, *chain: Any):
         """Log an info message if verbosity is enabled.
 
         Args:
@@ -84,25 +94,25 @@ class LogManager:
         Returns:
             True if info was printed, false otherwise.
         """
-        if not self.__check_suppress(chain):
-            if self.driftwood.config["log"]["verbose"]:
-                self.__print(["INFO"] + list(chain))
-                return True
-        return False
-
-    def __print(self, chain):
-        """Format and print the string.
-
-        Args:
-            chain: A list of strings to be separated by colon-spaces and printed.
-        """
+        chain = list(chain)
 
         # Convert everything to strings.
         for c in range(len(chain)):
             if type(chain[c]) != str:
                 chain[c] = str(chain[c])
 
-        # Print it.
+        if not self.__check_suppress(chain):
+            if self.driftwood.config["log"]["verbose"]:
+                self.__print(["INFO"] + chain)
+                return True
+        return False
+
+    def __print(self, chain: List[str]) -> None:
+        """Format and print the string.
+
+        Args:
+            chain: A list of strings to be separated by colon-spaces and printed.
+        """
         ticks = "[{0}] ".format(self.driftwood.tick.count)
         line = ticks + ": ".join(chain)
         print(line)
@@ -110,7 +120,7 @@ class LogManager:
             self.__file.write(line+'\n')
         sys.stdout.flush()
 
-    def __check_suppress(self, chain, halt=False):
+    def __check_suppress(self, chain: List[str], halt: bool=False) -> bool:
         """Checks whether or not the chain matches a suppression rule.
         """
         if halt:
@@ -125,7 +135,7 @@ class LogManager:
                 return True
         return False
 
-    def __test_file_open(self):
+    def __test_file_open(self) -> bool:
         """Test if we can create or open the log file.
         """
         try:
@@ -134,7 +144,7 @@ class LogManager:
         except:
             return False
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         if self.__file:

--- a/src/pathmanager.py
+++ b/src/pathmanager.py
@@ -28,7 +28,10 @@
 
 import os
 import platform
+from typing import List, Optional
 import zipfile
+
+from __main__ import _Driftwood, CHECK, CheckFailure
 
 
 class PathManager:
@@ -44,7 +47,7 @@ class PathManager:
         driftwood: Base class instance.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """PathManager class initializer.
 
         Args:
@@ -66,16 +69,16 @@ class PathManager:
         else:
             self.rebuild()
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         if self.find(item):
             return True
         return False
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Optional[str]:
         if self.__contains__(item):
             return self.find(item)
 
-    def examine(self, pathname):
+    def examine(self, pathname: str) -> List[str]:
         """Examine a directory or zip archive pathname and return the list of filenames therein.
 
         Args:
@@ -115,9 +118,9 @@ class PathManager:
         except:
             self.driftwood.log.msg("ERROR", "Path", "examine", "could not examine pathname", pathname)
 
-        return tuple(filelist)
+        return filelist
 
-    def rebuild(self):
+    def rebuild(self) -> bool:
         """Rebuild the vfs.
 
         Rebuild the virtual filesystem from the path list, and make sure the base module is at the top.
@@ -143,7 +146,7 @@ class PathManager:
 
         return True
 
-    def prepend(self, pathnames):
+    def prepend(self, pathnames: List[str]) -> bool:
         """Prepend pathnames to the path list.
 
         Prepend additional pathnames to the path list, preserving their order. If any of the pathnames already exist,
@@ -180,7 +183,7 @@ class PathManager:
 
         return True
 
-    def append(self, pathnames):
+    def append(self, pathnames: List[str]) -> bool:
         """Append pathnames to the path list.
 
         Append additional pathnames to the path list, preserving their order. If any of the pathnames already exist,
@@ -216,7 +219,7 @@ class PathManager:
 
         return True
 
-    def remove(self, pathnames):
+    def remove(self, pathnames: List[str]) -> bool:
         """Remove pathnames from the path list if present.
 
         Args:
@@ -252,7 +255,7 @@ class PathManager:
 
         return True
 
-    def find(self, filename, pathname=None):
+    def find(self, filename: str, pathname: str=None) -> Optional[str]:
         """Find a filename's pathname.
 
         Return the pathname which owns the filename, if present. If pathname is set, check that specific pathname for
@@ -282,7 +285,7 @@ class PathManager:
         else:
             return None
 
-    def find_script(self, filename):
+    def find_script(self, filename: str) -> Optional[str]:
         """Slightly less dumb hack to look for a compiled script if the uncompiled script cannot be found or vice versa.
         """
         # Input Check

--- a/src/resourcemanager.py
+++ b/src/resourcemanager.py
@@ -30,8 +30,10 @@ import json
 import os
 import sys
 import traceback
+from typing import Any, Optional
 import zipfile
 
+from __main__ import _Driftwood, CHECK, CheckFailure
 import filetype
 
 
@@ -44,7 +46,7 @@ class ResourceManager:
         driftwood: Base class instance.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """ResourceManager class initializer.
 
         Args:
@@ -54,7 +56,7 @@ class ResourceManager:
         self.__injections = {}
         self.__duplicate_file_counts = {}
 
-    def inject(self, filename, data):
+    def inject(self, filename: str, data: Any) -> bool:
         """Inject data to be retrieved later by a fake filename.
 
         This is checked before the filesystem and invalidates the cache, so if you overwrite an existing filename you
@@ -80,7 +82,7 @@ class ResourceManager:
         self.driftwood.log.info("Resource", "injected", filename)
         return True
 
-    def uninject(self, filename):
+    def uninject(self, filename: str) -> bool:
         """Delete injected data.
 
         Args:
@@ -104,7 +106,7 @@ class ResourceManager:
         self.driftwood.log.msg("ERROR", "Resource", "uninject", "no such file", filename)
         return False
 
-    def request_json(self, filename):
+    def request_json(self, filename) -> Optional[Any]:
         """Retrieve a dictionary of JSON data.
 
         Args:
@@ -138,7 +140,7 @@ class ResourceManager:
             self.driftwood.cache.upload(filename, None)
             return None
 
-    def request_audio(self, filename, music=False):
+    def request_audio(self, filename: str, music: bool=False) -> Optional[filetype.AudioFile]:
         """Retrieve an internal abstraction of an audio file.
 
         Args:
@@ -167,7 +169,7 @@ class ResourceManager:
             self.driftwood.cache.upload(filename, None)
             return None
 
-    def request_font(self, filename, ptsize):
+    def request_font(self, filename: str, ptsize: int) -> Optional[filetype.FontFile]:
         """Retrieve an internal abstraction of a font file.
 
         Args:
@@ -197,7 +199,7 @@ class ResourceManager:
             self.driftwood.cache.upload(cache_name, None)
             return None
 
-    def request_image(self, filename):
+    def request_image(self, filename: str) -> Optional[filetype.ImageFile]:
         """Retrieve an internal abstraction of an image file.
 
         Args:
@@ -224,7 +226,7 @@ class ResourceManager:
             self.driftwood.cache.upload(filename, None)
             return None
 
-    def request_duplicate_image(self, filename):
+    def request_duplicate_image(self, filename: str) -> Optional[filetype.ImageFile]:
         """Retrieve an internal abstraction of an image file. This object will not be shared with any other
         consumers so is free to be modified.
 
@@ -258,7 +260,7 @@ class ResourceManager:
 
         return obj
 
-    def _request(self, filename, binary=False):
+    def _request(self, filename: str, binary: bool=False) -> Optional[bytes]:
         """Retrieve the contents of a file.
 
         Args:

--- a/src/spritesheet.py
+++ b/src/spritesheet.py
@@ -26,8 +26,10 @@
 # IN THE SOFTWARE.
 # **********
 
-from ctypes import byref, c_int
+from ctypes import byref
 from sdl2 import *
+
+import entitymanager
 
 
 class Spritesheet:
@@ -43,7 +45,7 @@ class Spritesheet:
         imageheight: Height of the sprite sheet in pixels.
     """
 
-    def __init__(self, entitymanager, filename):
+    def __init__(self, entitymanager: 'entitymanager.EntityManager', filename: str):
         """Spritesheet class initializer.
 
         Args:
@@ -61,7 +63,7 @@ class Spritesheet:
 
         self.__prepare_spritesheet()
 
-    def __prepare_spritesheet(self):
+    def __prepare_spritesheet(self) -> None:
         self.image = self.__resource.request_image(self.filename)
         self.texture = self.image.texture
 

--- a/src/tilemap.py
+++ b/src/tilemap.py
@@ -26,6 +26,8 @@
 # IN THE SOFTWARE.
 # **********
 
+from __main__ import _Driftwood
+import areamanager
 import layer
 import tileset
 
@@ -46,7 +48,7 @@ class Tilemap:
         tilesets: The list of Tileset class instances for each tileset.
     """
 
-    def __init__(self, driftwood, area):
+    def __init__(self, driftwood: _Driftwood, area: 'areamanager.AreaManager'):
         """Tilemap class initializer.
 
         Args:
@@ -69,26 +71,26 @@ class Tilemap:
         # This contains the JSON of the Tiled map.
         self.__tilemap = {}
 
-    def __contains__(self, item):
+    def __contains__(self, item) -> bool:
         if len(self.layers) > item:
             return True
         return False
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> 'layer.Layer':
         if len(self.layers) > item:
             return self.layers[item]
 
-    def new_layer(self):
+    def new_layer(self) -> int:
         """Create a new virtual tile layer.
 
         Returns:
             Layer z position.
         """
         fakedata = {"data": [0] * (self.width * self.height)}
-        self.layers.append(layer.Layer(self, fakedata, len(self.layers)))
+        self.layers.append(layer.Layer(self.driftwood, self, fakedata, len(self.layers)))
         return self.layers[-1].zpos
 
-    def _read(self, filename, data):
+    def _read(self, filename: str, data: dict) -> bool:
         """Read and abstract a Tiled map.
 
         Reads the JSON Tiled map and processes its information into useful abstractions. This method is marked private
@@ -171,7 +173,7 @@ class Tilemap:
 
         return True
 
-    def __expand_properties(self):
+    def __expand_properties(self) -> None:
         new_props = {}
         old_props = []
 
@@ -188,7 +190,7 @@ class Tilemap:
         for prop in old_props:
             del self.properties[prop]
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         for t in range(len(self.tilesets)):

--- a/src/tileset.py
+++ b/src/tileset.py
@@ -27,6 +27,10 @@
 # **********
 
 import os
+from typing import Optional
+
+from __main__ import _Driftwood, CHECK, CheckFailure
+import tilemap
 
 
 class Tileset:
@@ -52,7 +56,7 @@ class Tileset:
         tileproperties: A dictionary containing mappings of tile GIDs to properties that apply to that GID.
     """
 
-    def __init__(self, driftwood, tilemap):
+    def __init__(self, driftwood: _Driftwood, tilemap: 'tilemap.Tilemap'):
         """Tileset class initializer.
 
         Args:
@@ -78,7 +82,7 @@ class Tileset:
         self.properties = {}
         self.tileproperties = {}
 
-    def load(self, tilemap_filename, tileset_json):
+    def load(self, tilemap_filename: str, tileset_json: dict) -> Optional[bool]:
         """Populate a Tileset with data from a Tiled map's tileset object.
 
         Args:
@@ -112,7 +116,7 @@ class Tileset:
                 return False
             return True
 
-    def __prepare(self, image_base_path, tileset_json, firstgid):
+    def __prepare(self, image_base_path: str, tileset_json: dict, firstgid: int) -> bool:
         """Load values into our tileset."""
         self.name = tileset_json["name"]
         self.imagewidth = tileset_json["imagewidth"]
@@ -143,7 +147,7 @@ class Tileset:
             return False
 
     @staticmethod
-    def __resolve_path(base_filename, filename):
+    def __resolve_path(base_filename: str, filename: str) -> str:
         """Determine the location of a file that was defined relative to another"""
         if os.path.dirname(base_filename):
             return os.path.normpath(os.path.dirname(base_filename) + os.path.sep + filename)

--- a/src/widgetmanager.py
+++ b/src/widgetmanager.py
@@ -26,10 +26,13 @@
 # IN THE SOFTWARE.
 # **********
 
+from typing import ItemsView, Optional
+
 from sdl2 import *
 from sdl2.ext import *
 from sdl2.sdlttf import *
 
+from __main__ import _Driftwood
 import widget
 
 
@@ -44,7 +47,7 @@ class WidgetManager:
         selected: Whether or not this widget is the selected widget. ex. a selected button in a UI menu.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         self.driftwood = driftwood
 
         self.widgets = {}
@@ -58,21 +61,21 @@ class WidgetManager:
 
         self.__prepare()
 
-    def __contains__(self, wid):
+    def __contains__(self, wid: int) -> bool:
         if self.widget(wid):
             return True
         return False
 
-    def __getitem__(self, wid):
+    def __getitem__(self, wid: int) -> Optional[widget.Widget]:
         return self.widget(wid)
 
-    def __delitem__(self, wid):
+    def __delitem__(self, wid) -> bool:
         return self.kill(wid)
 
-    def __iter__(self):
+    def __iter__(self) -> ItemsView:
         return self.widgets.items()
 
-    def select(self, wid):
+    def select(self, wid: int) -> bool:
         """Select the specified widget. Previously selected widget is released.
 
         An example is selecting a button in a menu or selecting a text input box, out of the other widgets on screen.
@@ -92,7 +95,7 @@ class WidgetManager:
         self.selected = wid
         return True
 
-    def release(self):
+    def release(self) -> bool:
         """Release the currently selected widget so that no widgets are selected.
 
         Returns:
@@ -105,7 +108,14 @@ class WidgetManager:
         self.selected = None
         return True
 
-    def container(self, imagefile=None, parent=None, x=0, y=0, width=0, height=0, active=True):
+    def container(self,
+                  imagefile: str=None,
+                  parent: int=None,
+                  x: int=0,
+                  y: int=0,
+                  width: int=0,
+                  height: int=0,
+                  active: bool=True) -> Optional[int]:
         """Create a new container widget.
 
         A container widget can have a background image, and other widgets can be contained by it. Widgets in a container
@@ -148,8 +158,17 @@ class WidgetManager:
 
         return new_widget.wid
 
-    def text(self, contents, fontfile, ptsize, parent=None, x=0, y=0, width=-1, height=-1, color="000000FF",
-             active=True):
+    def text(self,
+             contents: str,
+             fontfile: int,
+             ptsize: int,
+             parent: int=None,
+             x: int=0,
+             y: int=0,
+             width: int=-1,
+             height: int=-1,
+             color: str="000000FF",
+             active: bool=True):
         """Create a new text widget.
 
             A text widget puts text on the screen. It cannot have a background image, but can have a color.
@@ -190,7 +209,7 @@ class WidgetManager:
 
         return new_widget.wid
 
-    def activate(self, wid):
+    def activate(self, wid: int) -> bool:
         """Activate a widget. This widget becomes visible.
         
         Args:
@@ -203,7 +222,7 @@ class WidgetManager:
         self.driftwood.log.msg("ERROR", "Widget", "activate", "attempt to activate nonexistent widget", wid)
         return False
 
-    def deactivate(self, wid):
+    def deactivate(self, wid: int) -> bool:
         """Deactivate a widget. This widget becomes invisible.
 
         Args:
@@ -216,7 +235,7 @@ class WidgetManager:
         self.driftwood.log.msg("ERROR", "Widget", "deactivate", "attempt to deactivate nonexistent widget", wid)
         return False
 
-    def kill(self, wid):
+    def kill(self, wid: int) -> bool:
         """Kill a widget.
 
         Args:
@@ -231,7 +250,7 @@ class WidgetManager:
         self.driftwood.log.msg("ERROR", "Widget", "kill", "attempt to kill nonexistent widget", wid)
         return False
 
-    def widget(self, wid):
+    def widget(self, wid: int) -> Optional[widget.Widget]:
         """Get a widget by widget id.
 
         Args:
@@ -241,7 +260,7 @@ class WidgetManager:
             return self.widgets[wid]
         return None
 
-    def reset(self):
+    def reset(self) -> bool:
         """Destroy all widgets.
         """
         for widget in self.widgets:
@@ -251,7 +270,7 @@ class WidgetManager:
         self.selected = None
         return True
 
-    def _draw_widgets(self):
+    def _draw_widgets(self) -> None:
         """Copy the widgets into FrameManager. This is signaled by AreaManager once the area is drawn."""
         for wid in sorted(self.widgets.keys()):
             if self.widgets[wid].active and self.widgets[wid].srcrect():  # It's visible, draw it.
@@ -270,7 +289,7 @@ class WidgetManager:
                         if type(r) is int and r < 0:
                             self.driftwood.log.msg("ERROR", "Widget", "_draw_widgets", "SDL", SDL_GetError())
 
-    def __prepare(self):
+    def __prepare(self) -> None:
         """Initialize some things we need to get started.
         """
         if TTF_Init() < 0:
@@ -279,7 +298,7 @@ class WidgetManager:
         self.__uifactory = UIFactory(self.__spritefactory)
         self.__uiprocessor = UIProcessor()
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         for widget in self.widgets:

--- a/src/windowmanager.py
+++ b/src/windowmanager.py
@@ -27,9 +27,12 @@
 # **********
 
 from ctypes import byref
+from typing import List
 
 from sdl2 import *
 from sdl2.sdlimage import *
+
+from __main__ import _Driftwood
 
 class WindowManager:
     """The Window Manager
@@ -42,7 +45,7 @@ class WindowManager:
         renderer: The SDL Renderer attached to the window.
     """
 
-    def __init__(self, driftwood):
+    def __init__(self, driftwood: _Driftwood):
         """WindowManager class initializer.
 
         Initializes SDL, and creates a window and a renderer.
@@ -66,7 +69,7 @@ class WindowManager:
         self.driftwood.tick.register(self._tick, delay=1.0 / self.driftwood.config["window"]["maxfps"],
                                      during_pause=True)
 
-    def title(self, title):
+    def title(self, title: str) -> bool:
         """Set the window title.
 
         Args:
@@ -78,7 +81,7 @@ class WindowManager:
         SDL_SetWindowTitle(self.window, title.encode())
         return True
 
-    def refresh(self, area=False):
+    def refresh(self, area: bool=False) -> bool:
         """Force the window to redraw.
 
         Args:
@@ -92,13 +95,13 @@ class WindowManager:
             self.driftwood.area.changed = True
         return True
 
-    def resolution(self, width=None, height=None):
+    def resolution(self, width: int=None, height: int=None) -> List[int]:
         """Set or query the logical resolution of the window. This is different from the window dimensions.
-        
+
         Args:
             width: If set, the new logical width.
             height: If set, the new logical height.
-        
+
         Returns: A tuple containing the new resolution.
         """
         if width:
@@ -108,7 +111,7 @@ class WindowManager:
 
         return [self.__logical_width, self.__logical_height]
 
-    def _tick(self, seconds_past):
+    def _tick(self, seconds_past: float) -> None:
         """Tick callback which refreshes the renderer.
         """
         if self.driftwood.frame.changed:
@@ -127,7 +130,7 @@ class WindowManager:
 
             SDL_RenderPresent(self.renderer)
 
-    def __prepare(self):
+    def __prepare(self) -> None:
         """Prepare the window for use.
 
         Create a new window and renderer with the configured settings.
@@ -169,7 +172,7 @@ class WindowManager:
         # singular FPS.
         self.__setup_fps()
 
-    def __setup_fps(self):
+    def __setup_fps(self) -> None:
         """Query SDL to determine our monitor's refresh rate. Use this to set the engine's maximum frames per second
         if it's not alrady set.
         """
@@ -184,7 +187,7 @@ class WindowManager:
 
             self.driftwood.config["window"]["maxfps"] = refresh_rate
 
-    def _terminate(self):
+    def _terminate(self) -> None:
         """Cleanup before deletion.
         """
         SDL_DestroyRenderer(self.renderer)


### PR DESCRIPTION
Related to #142 and #148.

While adding type annotations, PyCharm showed some new highlights in the code that contained a few bugs so I fixed them. \o/

Some modifications were made to allow the type checker to work:

- The type checker doesn't follow builtin variables... it would have to solve [the halting problem](https://en.wikipedia.org/wiki/Halting_problem) to do that reliably. So all the source files that use `CHECK` or `CheckFailure` now `import` it from \_\_main__.
- Standardize on using a list rather than a tuple for srcrect and dstrect.
- Re-arrange the imports in \_\_main__.py (moving the import lines down lower) to avoid circular imports in Python 3. This is because \_\_main__.py imports pretty much every file, and those files all now import \_\_main__ themselves due to the first bullet point.

All the errors that PyCharm was throwing around from the `CHECK()` calls being undefined disappeared once `CHECK` was imported rather than being passed through the builtins.

## Why is this useful by itself?

It causes PyCharm to highlight more types of logic errors while working on the engine. It is useful to engine developers.

## What do static type check errors look like?

<img width="400" alt="screen shot 2017-05-07 at 7 39 26 pm" src="https://cloud.githubusercontent.com/assets/107998/25788313/0586069a-335d-11e7-835c-4b10e3e2aae7.png">

<img width="458" alt="screen shot 2017-05-07 at 7 42 41 pm" src="https://cloud.githubusercontent.com/assets/107998/25788365/6861667e-335d-11e7-968e-57329eb848bd.png">

<img width="392" alt="screen shot 2017-05-07 at 7 43 43 pm" src="https://cloud.githubusercontent.com/assets/107998/25788394/8cdd98d8-335d-11e7-9950-3d6445789594.png">

But it's not perfect:

<img width="305" alt="screen shot 2017-05-07 at 7 48 05 pm" src="https://cloud.githubusercontent.com/assets/107998/25788464/25f10f50-335e-11e7-8d81-e49bf14b30b1.png">

Ideally that should have shown an error. [PEP 526](https://www.python.org/dev/peps/pep-0526/) solves this but it requires Python 3.6. We can poke around with that if you want whenever we next upgrade the minimum language version.

## How do I write my own type annotations?

This is explained in detail by Guido in [PEP 484](https://www.python.org/dev/peps/pep-0484) but I'll try to condense the high level ideas below.

- Try to add annotations to the parameters and return values of all functions & methods. You can skip the `self` parameter on methods, though. Annotations are *completely optional* (like documentation!), so if you leave them out nothing bad will happen. But if you fill them in we'll get static type checks within that function and on all calls to that function.
- An annotation can either be a regular Python type like `str`, `float`, `int`, `list` (a list with no further restrictions), `dict`, etc. Or it can be the value `None` which stands for the type of the None value. Or it can be a type from the new [`typing`](https://www.python.org/dev/peps/pep-0484/#the-typing-module) module introduced with Python 3.5. The types from this module allow more expression so you can write `List[int]` (a list that is restricted to holding ints), `Union[str, int]` (something that can either be a string or an int) and so on. The `typing` module provides `Optional[T]` as shorthand for `Union[T, None]` since that's so common. This means something with the `Optional[str]` type can either be `None` or a `str`. Also, you can just write `float` in places where you'd ordinarily want to write `Union[int, float]` since PEP 484 says otherwise there'd be pretty much no reason to just use `float` by itself! Finally, an annotation can be a class that is in the current scope, either because it was declared earlier in the file above or a Python class that was imported from another file.
- If you need to refer to a class that doesn't exist yet because (1) it's lower down in the file, (2) it's currently being defined, or (3) Python is still importing the file it is supposed to come from (this happens as the result of a circular dependency) then put your annotation in a string. This is officially sanctioned by PEP 484 as proper and type checkers will understand it. You'll know you need to do this if adding a type annotation breaks the program & you get an error at runtime.

## Can I have a tool write the type annotations for me?

Yes, PyCharm and [Pytype](https://github.com/google/pytype) do this. The former is the easier of the two to use.

## Next steps

My plans for after this PR.

- [ ] There are some situations where PyCharm should show an error but it doesn't. I'm working on figuring out what causes this & hope to fix it.
- [ ] Get Mypy to work with these annotations.
- [ ] Add type checking to world code.