### PR TITLE
Clip hidden tiles

### DIFF
--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -26,10 +26,19 @@
 # IN THE SOFTWARE.
 # **********
 
+import math
 from sdl2 import *
 
 from __main__ import _Driftwood, CHECK, CheckFailure
 import tilemap
+
+
+def int_greater_than(x: float) -> int:
+    return math.ceil(x + 0.001)
+
+
+def int_smaller_than(x: float) -> int:
+    return math.floor(x - 0.001)
 
 
 class AreaManager:
@@ -154,6 +163,7 @@ class AreaManager:
         tilewidth = tilemap.tilewidth
         tileheight = tilemap.tileheight
         offset = self.offset
+        viewport_width, viewport_height = self.driftwood.window.resolution()
 
         # Start with the bottom layer and work up.
         for l in range(len(tilemap.layers)):
@@ -162,33 +172,83 @@ class AreaManager:
             srcrect = [-1, -1, tilewidth, tileheight]
             dstrect = [-1, -1, tilewidth, tileheight]
 
+            if self.driftwood.frame._frame is None:
+                # We need to know the size of the viewport.
+                continue
+
+            viewport_left_bound = -self.driftwood.frame._frame[2].x
+            viewport_top_bound = -self.driftwood.frame._frame[2].y
+            viewport_right_bound = viewport_left_bound + viewport_width - 1
+            viewport_bottom_bound = viewport_top_bound + viewport_height - 1
+
+            # A tile will show up onscreen when it intersects the viewport rectangle. We can express the state of this
+            # intersection with a set of four inequalities, all of which must be true for the intersection to occur.
+            # --------------------------------------------------------------------------------------------------------
+            # viewport_left_bound < tile_right_bound
+            # tile_left_bound < viewport_right_bound
+            # viewport_top_bound < tile_bottom_bound
+            # viewport_bottom_bound < tile_top_bound
+
+            # The following equations hold. (Unit of measurement is pixels.)
+            # --------------------------------------------------------------
+            # tile_left_bound   =  tile_x_pos      * tilewidth  + offset[0]
+            # tile_top_bound    =  tile_y_pos      * tileheight + offset[1]
+            # tile_right_bound  = (tile_x_pos + 1) * tilewidth  + offset[0] - 1
+            # tile_bottom_bound = (tile_y_pos + 1) * tileheight + offset[1] - 1
+
+            # Substitute the equations into the inequalities.
+            # -----------------------------------------------
+            # viewport_left_bound < (tile_x_pos + 1) * tilewidth  + offset[0] - 1
+            # viewport_top_bound  < (tile_y_pos + 1) * tileheight + offset[1] - 1
+            # tile_x_pos * tilewidth  + offset[0] < viewport_right_bound
+            # tile_y_pos * tileheight + offset[1] < viewport_bottom_bound
+
+            # Solve for tile_x_pos and tile_y_pos.
+            # ------------------------------------
+            # (viewport_left_bound - offset[0] + 1) / tilewidth  - 1 < tile_x_pos
+            # (viewport_top_bound  - offset[1] + 1) / tileheight - 1 < tile_y_pos
+            # tile_x_pos < (viewport_right_bound  - offset[0]) / tilewidth
+            # tile_y_pos < (viewport_bottom_bound - offset[1]) / tileheight
+
+            # We can now compute the minimum and maximum X and Y coordinates for visible tiles.
+            x_begin = int_greater_than((viewport_left_bound - offset[0] + 1) / tilewidth - 1)
+            y_begin = int_greater_than((viewport_top_bound - offset[1] + 1) / tileheight - 1)
+            x_end = int_smaller_than((viewport_right_bound - offset[0]) / tilewidth)
+            y_end = int_smaller_than((viewport_bottom_bound - offset[1]) / tileheight)
+
+            x_begin = max(0, x_begin)
+            y_begin = max(0, y_begin)
+            x_end = min(x_end, tilemap.height - 1)
+            y_end = min(y_end, tilemap.width - 1)
+
             # Draw each tile in the layer into its position.
-            for t in range(tilemap.width * tilemap.height):
-                # Retrieve data about the tile.
-                tile = layer.tiles[t]
-                tileset = tile.tileset
+            for y in range(y_begin, y_end + 1):
+                for x in range(x_begin, x_end + 1):
+                    # Retrieve data about the tile.
+                    tile = layer.tiles[y * tilemap.width + x]
+                    tileset = tile.tileset
 
-                if not tileset and not tile.gid:
-                    # This is a dummy tile, don't draw it.
-                    continue
+                    if not tileset and not tile.gid:
+                        # This is a dummy tile, don't draw it.
+                        continue
 
-                member = tile.members[tile._Tile__cur_member]
+                    member = tile.members[tile._Tile__cur_member]
 
-                if member == -1:
-                    # This tile is invisible at this point in its animation, don't draw it.
-                    continue
+                    if member == -1:
+                        # This tile is invisible at this point in its animation, don't draw it.
+                        continue
 
-                # Get the source and destination rectangles needed by SDL_RenderCopy.
-                srcrect[0] = member % tileset.width * tilewidth
-                srcrect[1] = member // tileset.width * tileheight
+                    # Get the source and destination rectangles needed by SDL_RenderCopy.
+                    srcrect[0] = member % tileset.width * tilewidth
+                    srcrect[1] = member // tileset.width * tileheight
 
-                dstrect[0] = tile.pos[0] * tilewidth + offset[0]
-                dstrect[1] = tile.pos[1] * tileheight + offset[1]
+                    dstrect[0] = x * tilewidth + offset[0]
+                    dstrect[1] = y * tileheight + offset[1]
 
-                # Copy the tile onto our frame.
-                r = self.driftwood.frame.copy(tileset.texture, srcrect, dstrect)
-                if r < 0:
-                    self.driftwood.log.msg("ERROR", "Area", "__build_frame", "SDL", SDL_GetError())
+                    # Copy the tile onto our frame.
+                    r = self.driftwood.frame.copy(tileset.texture, srcrect, dstrect)
+                    if r < 0:
+                        self.driftwood.log.msg("ERROR", "Area", "__build_frame", "SDL", SDL_GetError())
 
             # Draw the lights onto the layer.
             for light in self.driftwood.light.layer(l):

--- a/src/areamanager.py
+++ b/src/areamanager.py
@@ -324,9 +324,9 @@ class AreaManager:
         # intersection with a set of four inequalities, all of which must be true for the intersection to occur.
         # --------------------------------------------------------------------------------------------------------
         # viewport_left_bound < tile_right_bound
-        # tile_left_bound < viewport_right_bound
         # viewport_top_bound < tile_bottom_bound
-        # viewport_bottom_bound < tile_top_bound
+        # tile_left_bound < viewport_right_bound
+        # tile_top_bound < viewport_bottom_bound
 
         # The following equations hold. (Unit of measurement is pixels.)
         # --------------------------------------------------------------

--- a/src/tilemap.py
+++ b/src/tilemap.py
@@ -140,6 +140,11 @@ class Tilemap:
 
         # Build the tileset abstractions.
         for tileset_json in self.__tilemap["tilesets"]:
+            if tileset_json["tilewidth"] != self.tilewidth or \
+               tileset_json["tileheight"] != self.tileheight:
+                # Tilemaps and tilesets must have the equal tile widths and heights.
+                return False
+
             ts = tileset.Tileset(self.driftwood, self)
             if not ts.load(filename, tileset_json):
                 return False  # There is no way we can continue without our tilesets.


### PR DESCRIPTION
Fixes #159.

### Highlights

- Produces a 20% reduction in CPU usage while idling in the blue2 area.
- Increases framerate of a 100x100x2 sized area from 2 FPS to 43 FPS. (A 1x1x2 sized area also gets 43 FPS so we're hitting a bottleneck somewhere else that's preventing us from hitting 60, but with this patch an arbitrarily-sized area should be perfectly capable of hitting 60 just fine.)

### Lowlights

- Right now, the first frame drawn upon startup draws *all* tiles, rather than just the visible ones. To fix this bug, we need to tell AreaManager what the viewport bounds will be. Do we only calculate the bounds *after* asking AreaManager to render? Is there some way we can move this calculation earlier?
- AreaManager steals access to some private variables. Where this happens, code could stand to be improved.